### PR TITLE
feat: topic type numbers (full-name)

### DIFF
--- a/docs/columns/topic_type.md
+++ b/docs/columns/topic_type.md
@@ -1,15 +1,17 @@
 {% docs topic_type %}
 
-'Section Type' (or Topic Type) indicates the type of section associated with the topic.
+'Section Type' (or Topic Type) indicates the type of section associated with the topic. This is the acronym.
 
-| Acronym |           Section Type           |                                                    Description                                                    |
-| ------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| BI      | Bill                             | A legislative proposal presented for debate and approval within the parliament.                                   |
-| BP      | Budget Proposal                  | Signifies a proposal related to the national or organizational budget, detailing financial plans and allocations. |
-| OA      | Oral Answer                      | Indicate a session where members of the parliament provide oral answers to questions posed by their colleagues.   |
-| OS      | Oral Statement                   | Denotes a session where a member makes an oral statement on a particular issue.                                   |
-| WA      | Written Answer                   | Signifies a session where members provide written responses to questions submitted by their colleagues.           |
-| WS      | Written Statement                | Represent a session where a member submits a written statement on a specific matter.                              |
-| WANA    | Written Answer to a Named Member | Indicate a session where a written answer is specifically addressed to a named member of the parliament.          |
+'Section Type Name' indicates the full name of the section.
+
+| Acronym | Section Type Name                                                               |
+|---------|---------------------------------------------------------------------------------|
+| BI      | Bill Introduced                                                                 |
+| BP      | Second or Third Reading Bills                                                   |
+| OA      | Oral Answers to Questions                                                       |
+| OS      | Oral Statement                                                                  |
+| WA      | Written Answers to Questions                                                    |
+| WS      | Correction by Written Statements                                                |
+| WANA    | Written Answer to Question for Oral Answer not Answered by End of Question Time |
 
 {% enddocs %}

--- a/models/dim/dim_topics.sql
+++ b/models/dim/dim_topics.sql
@@ -4,7 +4,7 @@
     )
 }}
 
-with source as (
+with topics as (
     select
         topic_id,
         date,
@@ -12,7 +12,27 @@ with source as (
         title,
         section_type
     from {{ ref('stg_topics') }}
+),
+
+seed_topic_type as (
+    select
+        section_type_code,
+        section_type_name
+    from {{ ref('topic_type') }}
+),
+
+joined as (
+    select
+        topics.topic_id,
+        topics.date,
+        topics.topic_order,
+        topics.title,
+        topics.section_type,
+        seed_topic_type.section_type_name
+    from topics
+    left join seed_topic_type
+        on topics.section_type = seed_topic_type.section_type
 )
 
 select *
-from source
+from joined

--- a/models/dim/dim_topics.sql
+++ b/models/dim/dim_topics.sql
@@ -31,7 +31,7 @@ joined as (
         seed_topic_type.section_type_name
     from topics
     left join seed_topic_type
-        on topics.section_type = seed_topic_type.section_type
+        on topics.section_type = seed_topic_type.section_type_code
 )
 
 select *

--- a/models/dim/schema.yml
+++ b/models/dim/schema.yml
@@ -38,3 +38,9 @@ models:
           description: '{{ doc("topic_title") }}'
         - name: section_type
           description: '{{ doc("topic_type") }}'
+          tests:
+            - not_null
+        - name: section_type_name
+          description: '{{ doc("topic_type") }}'
+          tests:
+            - not_null

--- a/models/mart/mart_speeches.sql
+++ b/models/mart/mart_speeches.sql
@@ -20,7 +20,8 @@ topics as (
     select
         topic_id,
         title,
-        section_type
+        section_type,
+        section_type_name
     from {{ ref('dim_topics') }}
 ),
 
@@ -61,6 +62,7 @@ joined as (
         -- topic information
         topics.title as topic_title,
         topics.section_type as topic_type,
+        topics.section_type_name as topic_type_name,
 
         -- speech information
         speeches.text as speech_text,

--- a/models/mart/schema.yml
+++ b/models/mart/schema.yml
@@ -55,6 +55,8 @@ models:
           description: '{{ doc("topic_title") }}'
         - name: topic_type
           description: '{{ doc("topic_type") }}'
+        - name: topic_type_name
+          description: '{{ doc("topic_type") }}'
         - name: speech_text
           description: '{{ doc("speech_text") }}'
         - name: count_speeches_words

--- a/seeds/topic_type.csv
+++ b/seeds/topic_type.csv
@@ -2,7 +2,7 @@ section_type_code,section_type_name
 BI,Bill Introduced 	
 BP,Second or Third Reading Bills
 OA,Oral Answers to Questions
-OS,Ordinary Sitting Business 	
+OS,Oral Statement
 WA,Written Answers to Questions 	
 WS,Correction by Written Statements
 WANA,Written Answer to Question for Oral Answer not Answered by End of Question Time

--- a/seeds/topic_type.csv
+++ b/seeds/topic_type.csv
@@ -1,0 +1,8 @@
+section_type_code,section_type_name
+BI,Bill Introduced 	
+BP,Second or Third Reading Bills
+OA,Oral Answers to Questions
+OS,Ordinary Sitting Business 	
+WA,Written Answers to Questions 	
+WS,Correction by Written Statements
+WANA,Written Answer to Question for Oral Answer not Answered by End of Question Time


### PR DESCRIPTION
Adds the full name for section types.
This will help new users of the parliament speeches identify what topic is being discussed.

See the seed file [topic_types.csv](https://github.com/jeremychia/singapore-parliament-speeches-dbt/pull/6/files#diff-5701fa1ca575c0b6c5c0f10fcd884ec1ea8e27239a6d17de01048a7b45ebe362R1-R8) for the list of section types.

For example, questions that can be answered with this information are:

* How many bills were introduced in the reading?
* How many bills went through the second or third reading?
* How many oral questions/written questions were there?

What this does is to introduce a new column `section_type_name` or `topic_type_name` on the models:

* `dim_topics`
* `mart_speeches`