### PR TITLE
feat: is_constitutional flag on topics

### DIFF
--- a/docs/columns/is_constitutional.md
+++ b/docs/columns/is_constitutional.md
@@ -1,0 +1,16 @@
+{% docs is_constitutional %}
+
+'Is Constitutional' is a boolean field indicating whether the topic concerns a constitution amendment.
+
+This applies only if:
+
+* The topic is was bill introduced ("BI") or bill in second or third reading ("BP").
+* The topic contains the word "Constitution".
+
+Typical examples of topic names which qualify are:
+
+* Constitution of the Republic of Singapore (Amendment) Bill
+* Constitution of the Republic of Singapore (Amendment No 2) Bill
+* Constitution of the Republic of Singapore (Amendment No 3) Bill 
+
+{% enddocs %}

--- a/models/dim/dim_topics.sql
+++ b/models/dim/dim_topics.sql
@@ -44,7 +44,7 @@ flags as (
         section_type,
         section_type_name,
         -- introduced in this cte
-        lower(title) like "%constitution%" and section_type in ("BI", "BP") as is_constitutional
+        section_type in ("BI", "BP") and lower(title) like "%constitution%" as is_constitutional
     from joined
 )
 

--- a/models/dim/dim_topics.sql
+++ b/models/dim/dim_topics.sql
@@ -32,6 +32,20 @@ joined as (
     from topics
     left join seed_topic_type
         on topics.section_type = seed_topic_type.section_type_code
+),
+
+flags as (
+    select
+        -- from previous cte
+        topic_id,
+        date,
+        topic_order,
+        title,
+        section_type,
+        section_type_name,
+        -- introduced in this cte
+        lower(title) like "%constitution%" and section_type in ("BI", "BP") as is_constitutional
+    from joined
 )
 
 select *

--- a/models/dim/schema.yml
+++ b/models/dim/schema.yml
@@ -44,3 +44,5 @@ models:
           description: '{{ doc("topic_type") }}'
           tests:
             - not_null
+        - name: is_constitutional
+          description: '{{ doc("is_constitutional") }}'

--- a/models/mart/mart_speeches.sql
+++ b/models/mart/mart_speeches.sql
@@ -63,6 +63,7 @@ joined as (
         topics.title as topic_title,
         topics.section_type as topic_type,
         topics.section_type_name as topic_type_name,
+        topics.is_constitutional as is_constitutional,
 
         -- speech information
         speeches.text as speech_text,

--- a/models/mart/schema.yml
+++ b/models/mart/schema.yml
@@ -57,6 +57,8 @@ models:
           description: '{{ doc("topic_type") }}'
         - name: topic_type_name
           description: '{{ doc("topic_type") }}'
+        - name: is_constitutional
+          description: '{{ doc("is_constitutional") }}'
         - name: speech_text
           description: '{{ doc("speech_text") }}'
         - name: count_speeches_words


### PR DESCRIPTION
To answer the following questions:
* Identify number of legislations that were introduced (constitutional/normal)

To distinguish between constitutional amendments and non-constitutional amendments, the flag `is_constitutional` is intended to serve that purpose. This is added on `dim_topics` and `mart_speeches`.

See [documentation](https://github.com/jeremychia/singapore-parliament-speeches-dbt/pull/7/files#diff-d68b1de4bd5f76985da4ea9cef83dc48731cc83a9022f06006d790f204d0c97dR5-R8) for the logic:

> The topic is constitutional if:
> 
> * The topic is was bill introduced ("BI") or bill in second or third reading ("BP").
> * The topic contains the word "Constitution".
