### PR TITLE
feat: primary, supplementary questions flag on speeches

### DIFF
--- a/docs/columns/is_primary_question.md
+++ b/docs/columns/is_primary_question.md
@@ -1,0 +1,9 @@
+{% docs is_primary_question %}
+
+Applicable only for speeches where the topic's section is Oral Answers (OA) or Written Answers (WA).
+
+Primary questions are listed on the Order Paper and are presented by MPs during the parliamentary session. They are the initial inquiries posed by MPs to ministers.
+
+If true, this is the speech which corresponds to the question asked which is applicable for oral or written answers. This is the first speech of the topic.
+
+{% enddocs %}

--- a/docs/columns/is_supplementary_question.md
+++ b/docs/columns/is_supplementary_question.md
@@ -1,0 +1,9 @@
+{% docs is_supplementary_question %}
+
+Applicable only for speeches where the topic's section is Oral Answers (OA) or Written Answers (WA).
+
+Supplementary questions are asked by MPs immediately after the minister's response to their primary question. They serve as follow-up inquiries seeking further clarification or additional information.
+
+If true, this is the speech which corresponds to the follow-up question(s) asked in relation to the initial response given to the primary question. One topic can have none, or more than one supplementary question.
+
+{% enddocs %}

--- a/docs/columns/replying_member_name.md
+++ b/docs/columns/replying_member_name.md
@@ -1,0 +1,7 @@
+{% docs replying_member_name %}
+
+Applicable only for speeches where the topic's section is Oral Answers (OA) or Written Answers (WA).
+
+This is the member who replied to the primary question (i.e. the next person to speak after the member who asked the primary question).
+
+{% enddocs %}

--- a/docs/columns/speech_order_by_topic.md
+++ b/docs/columns/speech_order_by_topic.md
@@ -1,0 +1,7 @@
+{% docs speech_order_by_topic %}
+
+The speech order by topic refers to the order in which the speech appears for any given topic.
+
+This order can inform, for example, which is the member who raised the motion or asked the question (first speech. in the topic) and who is the member primarily responsible for responding to the matter (second speech in the topic). 
+
+{% enddocs %}

--- a/models/fact/fact_speeches.sql
+++ b/models/fact/fact_speeches.sql
@@ -4,18 +4,54 @@
     )
 }}
 
-with source as (
-    select
-        speech_id,
-        date,
-        topic_id,
-        speech_order,
-        member_name,
-        text,
-        count_words,
-        count_characters
-    from {{ ref('stg_speeches') }}
+with speeches as (
+  select 
+    speeches.*,
+    topics.section_type,
+    row_number() over(partition by speeches.topic_id order by speeches.speech_order) as speech_order_by_topic
+  from {{ ref('stg_speeches') }} as speeches
+  left join p{{ ref('stg_topics') }} as topics
+    on speeches.topic_id = topics.topic_id
+),
+
+replying_member as (
+  select
+    topic_id,
+    member_name
+  from speeches
+  where speech_order_by_topic = 2
+    and section_type in ('OA', 'WA')
+),
+
+flag_primary_supplementary_question as (
+  select
+    speeches.*,
+    replying_member.member_name as replying_member_name,
+
+    speeches.speech_order_by_topic = 1 
+      and lower(speeches.text) like '%ask%' as is_primary_question,
+
+    speeches.speech_order_by_topic > 1 
+      and lower(speeches.text) like any ('%ask%', '%supplementary question%') 
+      and speeches.member_name != replying_member.member_name
+      as is_supplementary_question
+
+  from speeches
+  left join replying_member
+    on speeches.topic_id = replying_member.topic_id
 )
 
-select *
-from source
+select  
+  speech_id,
+  date,
+  topic_id,
+  speech_order,
+  member_name,
+  text,
+  count_words,
+  count_characters,
+  speech_order_by_topic,
+  replying_member_name,
+  coalesce(is_primary_question, false) as is_primary_question,
+  coalesce(is_supplementary_question, false) as is_supplementary_question
+from flag_primary_supplementary_question

--- a/models/fact/schema.yml
+++ b/models/fact/schema.yml
@@ -71,4 +71,11 @@ models:
                 min_value: 0
                 inclusive: false
                 severity: warn
-  
+        - name: speech_order_by_topic
+          description: '{{ doc("speech_order_by_topic") }}'
+        - name: replying_member_name
+          description: '{{ doc("replying_member_name") }}'
+        - name: is_primary_question
+          description: '{{ doc("is_primary_question") }}'
+        - name: is_supplementary_question
+          description: '{{ doc("is_supplementary_question") }}'


### PR DESCRIPTION
Answers the questions:

- [PQ] Number of primary PQs asked by MPs
- [PQ] Number of supplementary PQs asked by MPs

This is by no means a perfect measure and might still need to be refined. We can continue to tune this.

Please see the corresponding files the logic and definitions. The new fields created on `fact_speeches` are:

- `speech_order_by_topic`
- `replying_member_name`
- `is_primary_question`
- `is_supplementary_question`