### PR TITLE
bug: replace chairman with speaker

### DIFF
--- a/models/stg/stg_speeches.sql
+++ b/models/stg/stg_speeches.sql
@@ -10,7 +10,7 @@ with type_cast as (
         cast(speech_id as string) as speech_id,
         cast(topic_id as string) as topic_id,
         cast(speech_order as int64) as speech_order,
-        cast(member_name as string) as member_name,
+        cast(case when member_name_original like '%Chairman%' then 'Speaker' else member_name end as string) as member_name,
         cast(text as string) as text,
         date(left(topic_id, 10)) as date,
         cast(num_words as int64) as count_words,

--- a/models/stg/stg_speeches.sql
+++ b/models/stg/stg_speeches.sql
@@ -10,11 +10,18 @@ with type_cast as (
         cast(speech_id as string) as speech_id,
         cast(topic_id as string) as topic_id,
         cast(speech_order as int64) as speech_order,
-        cast(case when member_name_original like '%Chairman%' then 'Speaker' else member_name end as string) as member_name,
+        cast(
+            case
+                when
+                    member_name_original like '%Chairman%'
+                    then 'Speaker'
+                else member_name
+            end as string
+        ) as member_name,
         cast(text as string) as text,
-        date(left(topic_id, 10)) as date,
         cast(num_words as int64) as count_words,
-        cast(num_characters as int64) as count_characters
+        cast(num_characters as int64) as count_characters,
+        date(left(topic_id, 10)) as date
 
     from {{ source('raw', 'speeches') }}
 )


### PR DESCRIPTION
There are instances where the speaker is referred to as 'Chairman' rather than 'Speaker'.

This amendment in the staging later aims to address this.