### PR TITLE
feat: add topic names

### DIFF
--- a/docs/columns/topic_group_id.md
+++ b/docs/columns/topic_group_id.md
@@ -1,0 +1,15 @@
+{% docs topic_group_id %}
+
+Corresponds to the topic group number (ID) which is the result of a topic modelling.
+For the list of topics, use the following query:
+
+```sql
+select
+    topic as topic_group_id,
+    topic_summary as topic_group_name,
+    top_n_words
+from `singapore-parliament-speeches.topic_modelling.topic_names_16_nmf_20240330`
+order by topic_group_id
+```
+
+{% enddocs %}

--- a/docs/columns/topic_group_name.md
+++ b/docs/columns/topic_group_name.md
@@ -1,0 +1,15 @@
+{% docs topic_group_name %}
+
+Corresponds to the topic group's name, which is derived, using an LLM, from the top n words.
+For the list of topics, use the following query:
+
+```sql
+select
+    topic as topic_group_id,
+    topic_summary as topic_group_name,
+    top_n_words
+from `singapore-parliament-speeches.topic_modelling.topic_names_16_nmf_20240330`
+order by topic_group_id
+```
+
+{% enddocs %}

--- a/docs/models/ml_highest_topics.md
+++ b/docs/models/ml_highest_topics.md
@@ -1,0 +1,5 @@
+{% docs ml_highest_topics %}
+
+Shows the most likely topic classification by topic ID.
+
+{% enddocs %}

--- a/docs/models/ml_topic_names.md
+++ b/docs/models/ml_topic_names.md
@@ -1,0 +1,5 @@
+{% docs ml_topic_names %}
+
+Provides the summarised name (`topic_summary`) based on the top 15 words from the trained topic model. In addition, shows the top 15 words (`top_n_words`).
+
+{% enddocs %}

--- a/models/dim/dim_topics.sql
+++ b/models/dim/dim_topics.sql
@@ -21,6 +21,20 @@ seed_topic_type as (
     from {{ ref('topic_type') }}
 ),
 
+topic_group as (
+    select
+        topic_id,
+        topic_group_id
+    from {{ ref('stg_topic_group') }}
+),
+
+topic_name as (
+    select
+        topic_group_id,
+        topic_group_name
+    from {{ ref('stg_topic_names') }}
+),
+
 joined as (
     select
         topics.topic_id,
@@ -28,10 +42,16 @@ joined as (
         topics.topic_order,
         topics.title,
         topics.section_type,
-        seed_topic_type.section_type_name
+        seed_topic_type.section_type_name,
+        topic_group.topic_group_id,
+        topic_name.topic_group_name
     from topics
     left join seed_topic_type
         on topics.section_type = seed_topic_type.section_type_code
+    left join topic_group
+        on topics.topic_id = topic_group.topic_id
+    left join topic_name
+        on topic_group.topic_group_id = topic_name.topic_group_id
 ),
 
 flags as (
@@ -43,6 +63,8 @@ flags as (
         title,
         section_type,
         section_type_name,
+        topic_group_id,
+        topic_group_name,
         -- introduced in this cte
         section_type in ("BI", "BP") and lower(title) like "%constitution%" as is_constitutional
     from joined

--- a/models/dim/schema.yml
+++ b/models/dim/schema.yml
@@ -47,9 +47,9 @@ models:
         - name: topic_group_id
           description: '{{ doc("topic_group_id") }}'
           tests:
-            - not_null
-              config:
-                severity: warn
+            - not_null:
+                config:
+                  severity: warn
         - name: topic_group_name
           description: '{{ doc("topic_group_name") }}'
         - name: is_constitutional

--- a/models/dim/schema.yml
+++ b/models/dim/schema.yml
@@ -44,5 +44,13 @@ models:
           description: '{{ doc("topic_type") }}'
           tests:
             - not_null
+        - name: topic_group_id
+          description: '{{ doc("topic_group_id") }}'
+          tests:
+            - not_null
+              config:
+                severity: warn
+        - name: topic_group_name
+          description: '{{ doc("topic_group_name") }}'
         - name: is_constitutional
           description: '{{ doc("is_constitutional") }}'

--- a/models/properties.yml
+++ b/models/properties.yml
@@ -11,3 +11,11 @@ sources:
         description: '{{ doc("models_speeches") }}'
       - name: topics
         description: '{{ doc("models_topics") }}'
+  - name: topic_modelling
+    config:
+      enabled: true
+    tables:
+      - name: highest_topic_16_nmf_20240330
+        description: '{{ doc("ml_highest_topics") }}'
+      - name: topic_names_16_nmf_20240330
+        description: '{{ doc("ml_topic_names") }}'

--- a/models/stg/schema.yml
+++ b/models/stg/schema.yml
@@ -32,3 +32,19 @@ models:
         tests:
            - not_null
            - unique
+  - name: stg_topic_group
+    description: '{{ doc("ml_highest_topics") }}'
+    columns:
+      - name: topic_id
+        description: '{{ doc("topic_id") }}'
+        tests:
+          - not_null
+          - unique
+  - name: stg_topic_names
+    description: '{{ doc("ml_topic_names") }}'
+    columns:
+      - name: topic_group_id
+        description: '{{ doc("topic_group_id") }}'
+        tests:
+          - not_null
+          - unique

--- a/models/stg/stg_topic_group.sql
+++ b/models/stg/stg_topic_group.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+with type_cast as (
+    select
+        cast(topic_id as string) as topic_id,
+        cast(highest_topic as int64) as topic_group_id,
+        cast(highest_topic_distribution as float64) as topic_group_distribution
+    from {{ source('topic_modelling', 'highest_topic_16_nmf_20240330') }}
+)
+
+select *
+from type_cast

--- a/models/stg/stg_topic_names.sql
+++ b/models/stg/stg_topic_names.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+with type_cast as (
+    select
+        cast(topic as int64) as topic_group_id,
+        cast(topic_summary as string) as topic_group_summary,
+        cast(top_n_words as string) as topic_group_top_n_words
+    from {{ source('topic_modelling', 'topic_names_16_nmf_20240330') }}
+)
+
+select *
+from type_cast

--- a/models/stg/stg_topic_names.sql
+++ b/models/stg/stg_topic_names.sql
@@ -7,7 +7,7 @@
 with type_cast as (
     select
         cast(topic as int64) as topic_group_id,
-        cast(topic_summary as string) as topic_group_summary,
+        cast(topic_summary as string) as topic_group_name,
         cast(top_n_words as string) as topic_group_top_n_words
     from {{ source('topic_modelling', 'topic_names_16_nmf_20240330') }}
 )


### PR DESCRIPTION
As an analyst, I want to be able to classify the topics by broader groups (i.e. healthcare, education, etc.).
This PR adds the names of these broader groups as `topic_group_name` to `dim_topics`.

The derivation of these topics is based off the content of the speeches. See the following notebooks:

* [Selecting the best model and number of topics](https://github.com/jeremychia/singapore-parliament-speeches/blob/main/notebooks/Parliamentary_Data_Topic_Modelling.ipynb)
* [Using NMF for Topic Modelling](https://github.com/jeremychia/singapore-parliament-speeches/blob/main/notebooks/Parliamentary_Data_Topic_Modelling_(NMF).ipynb)

In this iteration, non-matrix factorisation is used, with k=16 topics.