### PR TITLE
feat: adding manual source for member's information not on parliament website

### DIFF
--- a/models/stg/google_sheet/schema.yml
+++ b/models/stg/google_sheet/schema.yml
@@ -1,0 +1,68 @@
+version: 2
+sources:
+  - name: google_sheets
+    description: >
+      This source contains data stored in Google Sheets that are manually maintained.
+    project: singapore-parliament-speeches
+    dataset: google_sheets
+    loader: external_table
+    tags:
+      - source
+      - google_sheet
+    tables:
+      - name: member_of_parliament
+        description: >
+          Constituency Data that were manually filled.
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/']
+            sheet_range: members_member_of_parliament
+            skip_leading_rows: 1
+        columns:
+          - name: member_name
+            data_type: STRING
+          - name: constituency
+            data_type: STRING
+          - name: from_date
+            data_type: STRING
+          - name: to_date
+            data_type: STRING
+          - name: accessed_at
+            data_type: STRING
+      - name: year_of_birth
+        description: >
+          Year of Birth Data that were manually filled.
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/']
+            sheet_range: members_year_of_birth
+            skip_leading_rows: 1
+        columns:
+          - name: member_name
+            data_type: STRING
+          - name: year_of_birth
+            data_type: STRING
+          - name: accessed_at
+            data_type: STRING
+      - name: office_holding
+        description: >
+          Office Holding (Appointments) Data that were manually filled.
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/']
+            sheet_range: members_office_holding
+            skip_leading_rows: 1
+        columns:
+          - name: member_name
+            data_type: STRING
+          - name: position
+            data_type: STRING
+          - name: from_date
+            data_type: STRING
+          - name: to_date
+            data_type: STRING
+          - name: accessed_at
+            data_type: STRING

--- a/models/stg/google_sheet/stg_gsheet_member_of_parliament.sql
+++ b/models/stg/google_sheet/stg_gsheet_member_of_parliament.sql
@@ -1,0 +1,14 @@
+with
+    source as (select * from {{ source("google_sheets", "member_of_parliament") }}),
+    renamed as (
+        select
+            {{ adapter.quote("member_name") }} as member_name,
+            {{ adapter.quote("constituency") }} as member_constituency,
+            cast({{ adapter.quote("from_date") }} as date) as effective_from_date,
+            cast({{ adapter.quote("to_date") }} as date) as effective_to_date,
+            cast({{ adapter.quote("accessed_at") }} as date) as accessed_at
+
+        from source
+    )
+select *
+from renamed

--- a/models/stg/google_sheet/stg_gsheet_office_holding.sql
+++ b/models/stg/google_sheet/stg_gsheet_office_holding.sql
@@ -1,0 +1,14 @@
+with
+    source as (select * from {{ source("google_sheets", "office_holding") }}),
+    renamed as (
+        select
+            {{ adapter.quote("member_name") }} as member_name,
+            {{ adapter.quote("position") }} as member_appointment,
+            cast({{ adapter.quote("from_date") }} as date) as effective_from_date,
+            cast({{ adapter.quote("to_date") }} as date) as effective_to_date,
+            cast({{ adapter.quote("accessed_at") }} as date) as accessed_at
+
+        from source
+    )
+select *
+from renamed

--- a/models/stg/google_sheet/stg_gsheet_year_of_birth.sql
+++ b/models/stg/google_sheet/stg_gsheet_year_of_birth.sql
@@ -1,0 +1,12 @@
+with
+    source as (select * from {{ source("google_sheets", "year_of_birth") }}),
+    renamed as (
+        select
+            {{ adapter.quote("member_name") }} as member_name,
+            cast({{ adapter.quote("year_of_birth") }} as int) as member_birth_year,
+            cast({{ adapter.quote("accessed_at") }} as date) as accessed_at
+
+        from source
+    )
+select *
+from renamed

--- a/models/stg/members_information/stg_members_office_holding.sql
+++ b/models/stg/members_information/stg_members_office_holding.sql
@@ -4,18 +4,32 @@ with
         select
             {{ adapter.quote("member_name") }} as member_name,
             {{ adapter.quote("position") }} as member_appointment,
-            {{ adapter.quote("from_date") }} as effective_from_date,
-            {{ adapter.quote("to_date") }} as effective_to_date
-
+            cast({{ adapter.quote("from_date") }} as date) as effective_from_date,
+            cast({{ adapter.quote("to_date") }} as date) as effective_to_date
         from source
     ),
+
+    -- union manually-filled information
+    manual_gsheet as (
+        select member_name, member_appointment, effective_from_date, effective_to_date
+        from {{ ref("stg_gsheet_office_holding") }}
+    ),
+
+    unioned as (
+        select member_name, member_appointment, effective_from_date, effective_to_date
+        from renamed
+        union all
+        select member_name, member_appointment, effective_from_date, effective_to_date
+        from manual_gsheet
+    ),
+
     add_latest_flag as (
         select
             *,
             effective_to_date
             is null  -- when it is null, this is the current appointment
             as is_latest_appointment
-        from renamed
+        from unioned
     )
 select *
 from add_latest_flag

--- a/models/stg/members_information/stg_members_year_of_birth.sql
+++ b/models/stg/members_information/stg_members_year_of_birth.sql
@@ -3,9 +3,21 @@ with
     renamed as (
         select
             {{ adapter.quote("member_name") }} as member_name,
-            {{ adapter.quote("year_of_birth") }} as member_birth_year,
+            cast({{ adapter.quote("year_of_birth") }} as int) as member_birth_year,
 
         from source
+    ),
+    -- union manually-filled information
+    manual_gsheet as (
+        select member_name, member_birth_year from {{ ref("stg_gsheet_year_of_birth") }}
+    ),
+
+    unioned as (
+        select member_name, member_birth_year
+        from renamed
+        union all
+        select member_name, member_birth_year
+        from manual_gsheet
     )
 select *
-from renamed
+from unioned

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,6 +1,8 @@
 packages:
 - package: dbt-labs/codegen
   version: 0.12.1
+- package: dbt-labs/dbt_external_tables
+  version: 0.9.0
 - package: dbt-labs/dbt_utils
   version: 1.1.1
-sha1_hash: acdde602cd2e228b1dac1cf1a7e5f98f12c16b3b
+sha1_hash: 116b1959f8b5157699f5dcfb3f0065c4c0d731c5

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,5 @@
 packages:
   - package: dbt-labs/codegen
     version: 0.12.1
+  - package: dbt-labs/dbt_external_tables
+    version: 0.9.0


### PR DESCRIPTION
* member's information was introduced in https://github.com/jeremychia/singapore-parliament-speeches-dbt/pull/15
* this was only for current member information
* past member information was collated manually, see [google sheet](https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/edit#gid=250722396)
* these sources (scraped from google sheets and manually compiled in gsheet) are unioned

> [!NOTE]
> when new columns are added, the source yaml needs to be adjusted, and it needs to be staged again.
> ```shell
> dbt run-operation stage_external_sources --args "select: google_sheets" --vars "ext_full_refresh: true"
> ```

> [!IMPORTANT]
> also, the gsheet had to be shared with the dbt service account for be access is possible.
> this was only made possible because bigquery supports staging google sheets as an external source.
> this is the service account: `dbt-user@singapore-parliament-speeches.iam.gserviceaccount.com`.