### PR TITLE
include bills introduced from parliamentary business

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -38,6 +38,10 @@ models:
       +materialized: table
       +schema: mart
       +tags: mart
+    mart_prep:
+      +materialized: table
+      +schema: mart_prep
+      +tags: mart_prep
     fact:
       +materialized: table
       +schema: fact

--- a/models/fact/fact_bill_activity.sql
+++ b/models/fact/fact_bill_activity.sql
@@ -70,8 +70,9 @@ with
     ),
 
     clean_title as (
-        select * except(title),
-        case
+        select
+            * except (title),
+            case
                 when title = 'Central Provident Fund (Amendment No.2) Bill'
                 then 'Central Provident Fund (Amendment No 2) Bill'
                 when title = 'Co-operatives Societies (Amendment) Bill'

--- a/models/fact/fact_bill_activity.sql
+++ b/models/fact/fact_bill_activity.sql
@@ -67,7 +67,55 @@ with
         select topics.date, unioned.topic_id, topics.title, unioned.reading
         from unioned
         left join topics on unioned.topic_id = topics.topic_id
+    ),
+
+    clean_title as (
+        select * except(title),
+        case
+                when title = 'Central Provident Fund (Amendment No.2) Bill'
+                then 'Central Provident Fund (Amendment No 2) Bill'
+                when title = 'Co-operatives Societies (Amendment) Bill'
+                then 'Co-operative Societies (Amendment) Bill'
+                when title = 'Criminal Law (Temporary Provisions) Amendment Bill'
+                then 'Criminal Law (Temporary Provisions) (Amendment) Bill'
+                when title = 'Final Supply (FY2015) Bill'
+                then 'Final Supply (FY 2015) Bill'
+                when
+                    title
+                    = 'Economic Expansion Incentives (Relief from Income Tax) (Amendment) Bill'
+                then
+                    'Economic Expansion Incentives (Relief From Income Tax) (Amendment) Bill'
+                when trim(title) = 'Financial Services and Markets (Amendments) Bill'
+                then 'Financial Services and Markets (Amendment) Bill'
+                when title = 'Good and Services Tax (Amendment) Bill'
+                then 'Goods and Services Tax (Amendment) Bill'
+                when title = 'Housing and Development (Amendment) Bill'
+                then 'Housing and Development Board (Amendment) Bill'
+                when title = 'Income Tax (Amendment) (No 3) Bill'
+                then 'Income Tax (Amendment No 3) Bill'
+                when
+                    title
+                    = 'Motor Vehicles (Third-party Risks and Compensation) (Amendment) Bill'
+                then
+                    'Motor Vehicles (Third-Party Risks and Compensation) (Amendment) Bill'
+                when title = 'Second Supplementary Supply (2021) Bill'
+                then 'Second Supplementary Supply (FY 2021) Bill'
+                when title = 'Statue Law Reform Bill'
+                then 'Statute Law Reform Bill'
+                when title = 'Supplementary Supply (FY2016) Bill'
+                then 'Supplementary Supply (FY 2016) Bill'
+                when title = 'Supplementary Supply (FY2019) Bill'
+                then 'Supplementary Supply (FY 2019) Bill'
+                when trim(title) = 'Supply BIll'
+                then 'Supply Bill'
+                when
+                    title
+                    = 'Tobacco (Control of Advertisements and Sale (Amendment) Bill'
+                then 'Tobacco (Control of Advertisements and Sale) (Amendment) Bill'
+                else trim(title)
+            end as title
+        from joined
     )
 
 select *
-from joined
+from clean_title

--- a/models/fact/fact_bill_activity.sql
+++ b/models/fact/fact_bill_activity.sql
@@ -83,15 +83,15 @@ with
                 then 'Final Supply (FY 2015) Bill'
                 when
                     title
-                    = 'Economic Expansion Incentives (Relief from Income Tax) (Amendment) Bill'
+                    = 'Economic Expansion Incentives (Relief From Income Tax) (Amendment) Bill'
                 then
-                    'Economic Expansion Incentives (Relief From Income Tax) (Amendment) Bill'
+                    'Economic Expansion Incentives (Relief from Income Tax) (Amendment) Bill'
                 when trim(title) = 'Financial Services and Markets (Amendments) Bill'
                 then 'Financial Services and Markets (Amendment) Bill'
                 when title = 'Good and Services Tax (Amendment) Bill'
                 then 'Goods and Services Tax (Amendment) Bill'
-                when title = 'Housing and Development (Amendment) Bill'
-                then 'Housing and Development Board (Amendment) Bill'
+                when title = 'Housing and Development Board (Amendment) Bill'
+                then 'Housing and Development (Amendment) Bill'
                 when title = 'Income Tax (Amendment) (No 3) Bill'
                 then 'Income Tax (Amendment No 3) Bill'
                 when
@@ -109,6 +109,12 @@ with
                 then 'Supplementary Supply (FY 2019) Bill'
                 when trim(title) = 'Supply BIll'
                 then 'Supply Bill'
+                when title = 'Supplementary Supply (FY2017) Bill'
+                then 'Supplementary Supply (FY 2017) Bill'
+                when title = 'Supplementary Supply (FY2022) Bill'
+                then 'Supplementary Supply (FY 2022) Bill'
+                when title like 'Supplementary Supply (FY2023) Bill%'
+                then 'Supplementary Supply (FY 2023) Bill'
                 when
                     title
                     = 'Tobacco (Control of Advertisements and Sale (Amendment) Bill'

--- a/models/fact/fact_bills_introduced.sql
+++ b/models/fact/fact_bills_introduced.sql
@@ -1,0 +1,14 @@
+with
+    source as (
+        select
+            bill_number,
+            title,
+            first_reading_date,
+            second_reading_date,
+            passed_date,
+            bill_pdf_link
+        from {{ ref("stg_parliamentary_business_bills_introduced") }}
+    )
+
+select *
+from source

--- a/models/fact/schema.yml
+++ b/models/fact/schema.yml
@@ -119,3 +119,23 @@ models:
                 min_value: 0
                 inclusive: false
                 severity: warn
+
+    - name: fact_bills_introduced
+      description: 'From parliament website {{ doc("models_bills") }}'
+      columns:
+        - name: bill_number
+          description: ''
+          tests:
+            - not_null
+            - unique
+        - name: title
+          description: ''
+        - name: first_reading_date
+          description: ''
+        - name: second_reading_date
+          description: ''
+        - name: passed_date
+          description: ''
+        - name: bill_pdf_link
+          description: ''
+

--- a/models/mart/mart_bills.sql
+++ b/models/mart/mart_bills.sql
@@ -13,9 +13,46 @@ with
             third_reading_date,
             third_reading_topic
         from {{ ref("mart_prep_bill_activity") }}
+    ),
+
+    bill_introduced as (
+        select
+            bill_number,
+            extract(year from first_reading_date) as year,
+            title,
+            first_reading_date,
+            second_reading_date,
+            passed_date,
+            bill_pdf_link
+        from {{ ref("fact_bills_introduced") }}
+    ),
+
+    joined as (
+        select
+            introduced.bill_number,
+            activity.year,
+            coalesce(introduced.title, activity.title) as title,
+            coalesce(
+                introduced.first_reading_date, activity.first_reading_date
+            ) as first_reading_date,
+            activity.first_reading_topic,
+            coalesce(
+                introduced.second_reading_date, activity.second_reading_date
+            ) as second_reading_date,
+            activity.second_reading_topic,
+            activity.third_reading_date,
+            activity.third_reading_topic,
+            introduced.passed_date,
+            introduced.bill_pdf_link
+        from bill_introduced as introduced
+        full join
+            bill_activity as activity
+            on introduced.title = activity.title
+            and introduced.year = activity.year
     )
 
 select
+    bill_number,
     year,
     title,
     first_reading_date,
@@ -24,10 +61,15 @@ select
     second_reading_topic,
     third_reading_date,
     third_reading_topic,
+    passed_date,
     date_diff(
         second_reading_date, first_reading_date, day
     ) as day_diff_first_second_reading,
     date_diff(
         third_reading_date, second_reading_date, day
-    ) as day_diff_second_third_reading
-from bill_activity
+    ) as day_diff_second_third_reading,
+    date_diff(
+        third_reading_date, second_reading_date, day
+    ) as day_diff_third_reading_passed,
+    bill_pdf_link
+from joined

--- a/models/mart/mart_bills.sql
+++ b/models/mart/mart_bills.sql
@@ -2,105 +2,7 @@
 
 
 with
-    processing as (
-        select
-            -- cleaning some titles to standardise them so they can be merged together
-            ba.reading,
-            ba.topic_id,
-            ba.date,
-            ba.title,
-            extract(year from ba.date) as year
-        from {{ ref("fact_bill_activity") }} as ba
-    ),
-
-    summarise as (
-        select
-            year,
-            replace(trim(title), '.', '') as title,
-            -- 1 first reading
-            min(case when left(reading, 1) = '1' then date end) as first_reading_date,
-            min_by(
-                topic_id, case when left(reading, 1) = '1' then date end
-            ) as first_reading_topic,
-            -- 2 second reading
-            min(case when left(reading, 1) = '2' then date end) as second_reading_date,
-            min_by(
-                topic_id, case when left(reading, 1) = '2' then date end
-            ) as second_reading_topic,
-            -- 3 third reading
-            max(case when left(reading, 1) = '3' then date end) as third_reading_date,
-            max_by(
-                topic_id, case when left(reading, 1) = '3' then date end
-            ) as third_reading_topic
-        from processing
-        group by 1, 2
-    ),
-
-    -- process bills where dates were joined across two years
-    complete as (
-        select
-            summarise.year,
-            summarise.title,
-            summarise.first_reading_date,
-            summarise.first_reading_topic,
-            summarise.second_reading_date,
-            summarise.second_reading_topic,
-            summarise.third_reading_date,
-            summarise.third_reading_topic
-        from summarise
-        where not (first_reading_date is null or second_reading_date is null)
-    ),
-
-    incomplete as (
-        select
-            summarise.year,
-            summarise.title,
-            summarise.first_reading_date,
-            summarise.first_reading_topic,
-            summarise.second_reading_date,
-            summarise.second_reading_topic,
-            summarise.third_reading_date,
-            summarise.third_reading_topic,
-            summarise.year + 1 as year_plus_1
-        from summarise
-        where first_reading_date is null or second_reading_date is null
-    ),
-
-    -- it is possible that the bill passage was raised across 2 years, to find this
-    -- information
-    incomplete_combine_across_different_years as (
-        select
-            i0.year,
-            i0.title,
-            coalesce(
-                i0.first_reading_date, i1.first_reading_date
-            ) as first_reading_date,
-            coalesce(
-                i0.first_reading_topic, i1.first_reading_topic
-            ) as first_reading_topic,
-            coalesce(
-                i0.second_reading_date, i1.second_reading_date
-            ) as second_reading_date,
-            coalesce(
-                i0.second_reading_topic, i1.second_reading_topic
-            ) as second_reading_topic,
-            coalesce(
-                i0.third_reading_date, i1.third_reading_date
-            ) as third_reading_date,
-            coalesce(
-                i0.third_reading_topic, i1.third_reading_topic
-            ) as third_reading_topic
-        from incomplete as i0
-        left join incomplete as i1 on i0.year_plus_1 = i1.year and i0.title = i1.title
-        -- to drop rows where information has been filled
-        qualify
-            not lag(i0.first_reading_date, 1) over (
-                partition by i0.title order by i0.year
-            )
-            is not null
-    ),
-
-    unioned as (
+    bill_activity as (
         select
             year,
             title,
@@ -110,18 +12,7 @@ with
             second_reading_topic,
             third_reading_date,
             third_reading_topic
-        from incomplete_combine_across_different_years
-        union all
-        select
-            year,
-            title,
-            first_reading_date,
-            first_reading_topic,
-            second_reading_date,
-            second_reading_topic,
-            third_reading_date,
-            third_reading_topic
-        from complete
+        from {{ ref("mart_prep_bill_activity") }}
     )
 
 select
@@ -139,4 +30,4 @@ select
     date_diff(
         third_reading_date, second_reading_date, day
     ) as day_diff_second_third_reading
-from unioned
+from bill_activity

--- a/models/mart/mart_bills.sql
+++ b/models/mart/mart_bills.sql
@@ -8,49 +8,7 @@ with
             ba.reading,
             ba.topic_id,
             ba.date,
-            case
-                when ba.title = 'Central Provident Fund (Amendment No.2) Bill'
-                then 'Central Provident Fund (Amendment No 2) Bill'
-                when ba.title = 'Co-operatives Societies (Amendment) Bill'
-                then 'Co-operative Societies (Amendment) Bill'
-                when ba.title = 'Criminal Law (Temporary Provisions) Amendment Bill'
-                then 'Criminal Law (Temporary Provisions) (Amendment) Bill'
-                when ba.title = 'Final Supply (FY2015) Bill'
-                then 'Final Supply (FY 2015) Bill'
-                when
-                    ba.title
-                    = 'Economic Expansion Incentives (Relief from Income Tax) (Amendment) Bill'
-                then
-                    'Economic Expansion Incentives (Relief From Income Tax) (Amendment) Bill'
-                when trim(ba.title) = 'Financial Services and Markets (Amendments) Bill'
-                then 'Financial Services and Markets (Amendment) Bill'
-                when ba.title = 'Good and Services Tax (Amendment) Bill'
-                then 'Goods and Services Tax (Amendment) Bill'
-                when ba.title = 'Housing and Development (Amendment) Bill'
-                then 'Housing and Development Board (Amendment) Bill'
-                when ba.title = 'Income Tax (Amendment) (No 3) Bill'
-                then 'Income Tax (Amendment No 3) Bill'
-                when
-                    ba.title
-                    = 'Motor Vehicles (Third-party Risks and Compensation) (Amendment) Bill'
-                then
-                    'Motor Vehicles (Third-Party Risks and Compensation) (Amendment) Bill'
-                when ba.title = 'Second Supplementary Supply (2021) Bill'
-                then 'Second Supplementary Supply (FY 2021) Bill'
-                when ba.title = 'Statue Law Reform Bill'
-                then 'Statute Law Reform Bill'
-                when ba.title = 'Supplementary Supply (FY2016) Bill'
-                then 'Supplementary Supply (FY 2016) Bill'
-                when ba.title = 'Supplementary Supply (FY2019) Bill'
-                then 'Supplementary Supply (FY 2019) Bill'
-                when trim(ba.title) = 'Supply BIll'
-                then 'Supply Bill'
-                when
-                    ba.title
-                    = 'Tobacco (Control of Advertisements and Sale (Amendment) Bill'
-                then 'Tobacco (Control of Advertisements and Sale) (Amendment) Bill'
-                else trim(ba.title)
-            end as title,
+            ba.title,
             extract(year from ba.date) as year
         from {{ ref("fact_bill_activity") }} as ba
     ),

--- a/models/mart/schema.yml
+++ b/models/mart/schema.yml
@@ -77,9 +77,13 @@ models:
             combination_of_columns:
               - year
               - title
+            config:
+              where: bill_number is null
 
       columns:
         - name: bill_number
+          tests:
+            - unique
         - name: year
         - name: first_reading_date
         - name: first_reading_topic

--- a/models/mart/schema.yml
+++ b/models/mart/schema.yml
@@ -79,6 +79,7 @@ models:
               - title
 
       columns:
+        - name: bill_number
         - name: year
         - name: first_reading_date
         - name: first_reading_topic
@@ -88,3 +89,6 @@ models:
         - name: day_diff_second_third_reading
         - name: third_reading_date
         - name: third_reading_topic
+        - name: day_diff_third_reading_passed
+        - name: passed_date
+        - name: bill_pdf_link

--- a/models/mart_prep/mart_prep_bill_activity.sql
+++ b/models/mart_prep/mart_prep_bill_activity.sql
@@ -116,7 +116,14 @@ with
             third_reading_date,
             third_reading_topic
         from complete
+    ),
+
+    clean_amendments as (
+        select
+            * except (title),
+            regexp_replace(title, r'(No)\s(\d)', r'\1. \2') as title
+        from unioned
     )
 
 select *
-from unioned
+from clean_amendments

--- a/models/mart_prep/mart_prep_bill_activity.sql
+++ b/models/mart_prep/mart_prep_bill_activity.sql
@@ -3,12 +3,7 @@
 
 with
     bill_activity as (
-        select
-            reading,
-            topic_id,
-            date,
-            title,
-            extract(year from date) as year
+        select reading, topic_id, date, title, extract(year from date) as year
         from {{ ref("fact_bill_activity") }}
     ),
 

--- a/models/mart_prep/mart_prep_bill_activity.sql
+++ b/models/mart_prep/mart_prep_bill_activity.sql
@@ -1,0 +1,127 @@
+{{ config(materialized="table") }}
+
+
+with
+    bill_activity as (
+        select
+            reading,
+            topic_id,
+            date,
+            title,
+            extract(year from date) as year
+        from {{ ref("fact_bill_activity") }}
+    ),
+
+    summarise as (
+        select
+            year,
+            replace(trim(title), '.', '') as title,
+            -- 1 first reading
+            min(case when left(reading, 1) = '1' then date end) as first_reading_date,
+            min_by(
+                topic_id, case when left(reading, 1) = '1' then date end
+            ) as first_reading_topic,
+            -- 2 second reading
+            min(case when left(reading, 1) = '2' then date end) as second_reading_date,
+            min_by(
+                topic_id, case when left(reading, 1) = '2' then date end
+            ) as second_reading_topic,
+            -- 3 third reading
+            max(case when left(reading, 1) = '3' then date end) as third_reading_date,
+            max_by(
+                topic_id, case when left(reading, 1) = '3' then date end
+            ) as third_reading_topic
+        from bill_activity
+        group by 1, 2
+    ),
+
+    -- process bills where dates were joined across two years
+    complete as (
+        select
+            summarise.year,
+            summarise.title,
+            summarise.first_reading_date,
+            summarise.first_reading_topic,
+            summarise.second_reading_date,
+            summarise.second_reading_topic,
+            summarise.third_reading_date,
+            summarise.third_reading_topic
+        from summarise
+        where not (first_reading_date is null or second_reading_date is null)
+    ),
+
+    incomplete as (
+        select
+            summarise.year,
+            summarise.title,
+            summarise.first_reading_date,
+            summarise.first_reading_topic,
+            summarise.second_reading_date,
+            summarise.second_reading_topic,
+            summarise.third_reading_date,
+            summarise.third_reading_topic,
+            summarise.year + 1 as year_plus_1
+        from summarise
+        where first_reading_date is null or second_reading_date is null
+    ),
+
+    -- it is possible that the bill passage was raised across 2 years, to find this
+    -- information
+    incomplete_combine_across_different_years as (
+        select
+            i0.year,
+            i0.title,
+            coalesce(
+                i0.first_reading_date, i1.first_reading_date
+            ) as first_reading_date,
+            coalesce(
+                i0.first_reading_topic, i1.first_reading_topic
+            ) as first_reading_topic,
+            coalesce(
+                i0.second_reading_date, i1.second_reading_date
+            ) as second_reading_date,
+            coalesce(
+                i0.second_reading_topic, i1.second_reading_topic
+            ) as second_reading_topic,
+            coalesce(
+                i0.third_reading_date, i1.third_reading_date
+            ) as third_reading_date,
+            coalesce(
+                i0.third_reading_topic, i1.third_reading_topic
+            ) as third_reading_topic
+        from incomplete as i0
+        left join incomplete as i1 on i0.year_plus_1 = i1.year and i0.title = i1.title
+        -- to drop rows where information has been filled
+        qualify
+            not lag(i0.first_reading_date, 1) over (
+                partition by i0.title order by i0.year
+            )
+            is not null
+    ),
+
+    unioned as (
+        select
+            year,
+            title,
+            first_reading_date,
+            first_reading_topic,
+            second_reading_date,
+            second_reading_topic,
+            third_reading_date,
+            third_reading_topic
+        from incomplete_combine_across_different_years
+        union all
+        select
+            year,
+            title,
+            first_reading_date,
+            first_reading_topic,
+            second_reading_date,
+            second_reading_topic,
+            third_reading_date,
+            third_reading_topic
+        from complete
+    )
+
+select *
+from unioned

--- a/models/properties.yml
+++ b/models/properties.yml
@@ -32,3 +32,10 @@ sources:
         description: '{{ doc("ml_highest_topics") }}'
       - name: topic_names_19_nmf_20240331
         description: '{{ doc("ml_topic_names") }}'
+
+  - name: parliamentary_business
+    config:
+      enabled: true
+    tables:
+      - name: bills_introduced
+        description: 'From parliament website {{ doc("models_bills") }}'

--- a/models/stg/parliamentary_business/schema.yml
+++ b/models/stg/parliamentary_business/schema.yml
@@ -1,0 +1,11 @@
+version: 2
+
+models:
+  - name: stg_parliamentary_business_bills_introduced
+    description: 'From parliament website {{ doc("models_bills") }}'
+    columns:
+      - name: bill_number
+        description: ''
+        tests:
+          - not_null
+          - unique

--- a/models/stg/parliamentary_business/stg_parliamentary_business_bills_introduced.sql
+++ b/models/stg/parliamentary_business/stg_parliamentary_business_bills_introduced.sql
@@ -1,0 +1,19 @@
+with
+    source as (
+        select * from {{ source("parliamentary_business", "bills_introduced") }}
+    ),
+    renamed as (
+        select
+            {{ adapter.quote("title") }} as title,
+            {{ adapter.quote("number") }} as bill_number,
+            {{ adapter.quote("pdf_link") }} as bill_pdf_link,
+            cast({{ adapter.quote("date_introduced") }} as date) as first_reading_date,
+            cast(
+                {{ adapter.quote("date_2nd_reading") }} as date
+            ) as second_reading_date,
+            cast({{ adapter.quote("date_passed") }} as date) as passed_date
+
+        from source
+    )
+select *
+from renamed

--- a/models/stg/parliamentary_business/stg_parliamentary_business_bills_introduced.sql
+++ b/models/stg/parliamentary_business/stg_parliamentary_business_bills_introduced.sql
@@ -14,6 +14,20 @@ with
             cast({{ adapter.quote("date_passed") }} as date) as passed_date
 
         from source
+    ),
+    cleaned as (
+        select
+            * except (title),
+            case
+                when title = 'Foreign Interference (countermeasures) Bill'
+                then 'Foreign Interference (Countermeasures) Bill'
+                when title = 'Monetary Authority of  Singapore (Amendment) Bill'
+                then 'Monetary Authority of Singapore (Amendment) Bill'
+                when bill_number = '22/2023'
+                then 'Constitution of the Republic of Singapore (Amendment No. 2) Bill'
+                else title
+            end as title
+        from renamed
     )
 select *
-from renamed
+from cleaned


### PR DESCRIPTION
this PR:
* introduces a new data source from [parliament's bills introduced page](https://www.parliament.gov.sg/parliamentary-business/bills-introduced) - see the [extractor here](https://colab.research.google.com/drive/1yc0-CLpUoBnqNGx5E1p7J5fFLFO2S8yo?authuser=1#scrollTo=ycZDcTolRbf7).
* refactoring to `bill_activity`
* cleans titles to standardise them for joins between two sources