### PR TITLE
feat: agg tables on speeches, marts

### DIFF
--- a/docs/models/agg_pri_questions_topics_by_member.md
+++ b/docs/models/agg_pri_questions_topics_by_member.md
@@ -1,0 +1,5 @@
+{% docs agg_pri_questions_topics_by_member %}
+
+TODO
+
+{% enddocs %}

--- a/docs/models/agg_speech_metrics_by_member.md
+++ b/docs/models/agg_speech_metrics_by_member.md
@@ -1,0 +1,5 @@
+{% docs agg_speech_metrics_by_member %}
+
+TODO
+
+{% enddocs %}

--- a/models/agg/agg_pri_questions_topics_by_member.sql
+++ b/models/agg/agg_pri_questions_topics_by_member.sql
@@ -1,0 +1,32 @@
+with
+    primary_questions as (
+        select
+            parliament,
+            extract(year from date) as year,
+            extract(month from date) as month,
+            member_name,
+            member_constituency,
+            ministry_addressed
+        from {{ ref("mart_speeches") }}
+        where
+            is_primary_question = true
+            and ministry_addressed is not null
+            and member_name != ''
+    ),
+
+    aggregated as (
+        select
+            parliament,
+            year,
+            month,
+            member_name,
+            member_constituency,
+            ministry_addressed,
+            count(*) as count_pri_questions
+        from primary_questions
+        group by all
+    )
+
+select *
+from aggregated
+order by member_name, parliament, year, month

--- a/models/agg/agg_speech_metrics_by_member.sql
+++ b/models/agg/agg_speech_metrics_by_member.sql
@@ -1,0 +1,97 @@
+with
+    speeches as (
+        select
+            parliament,
+            extract(year from date) as year,
+            extract(month from date) as month,
+            member_name,
+            member_constituency,
+            count(distinct date) as count_sittings_spoken,
+            count(distinct topic_id) as count_topics,
+            count(*) as count_speeches,
+            sum(count_speeches_words) as count_words,
+            countif(is_primary_question) as count_pri_questions,
+            sum(count_speeches_sentences) as count_sentences,
+            sum(count_speeches_syllables) as count_syllables
+        from {{ ref("mart_speeches") }}
+        where
+            member_name != ''
+            and not lower(member_name) like any ('%deputy%', '%speaker%', '%chairman%')
+        group by all
+    ),
+
+    attendance as (
+        select
+            parliament,
+            extract(year from date) as year,
+            extract(month from date) as month,
+            member_name,
+            member_constituency,
+            countif(is_present) as count_sittings_present,
+            count(*) as count_sittings_total
+        from {{ ref("mart_attendance") }}
+        where member_name != ''
+        group by all
+
+    ),
+
+    join_metrics as (
+        select
+            coalesce(speeches.parliament, attendance.parliament) as parliament,
+            coalesce(speeches.year, attendance.year) as year,
+            coalesce(speeches.month, attendance.month) as month,
+            coalesce(speeches.member_name, attendance.member_name) as member_name,
+            coalesce(
+                attendance.member_constituency, speeches.member_constituency
+            ) as member_constituency,
+
+            -- attendance-related
+            attendance.count_sittings_total,
+            attendance.count_sittings_present,
+
+            -- participation-related
+            coalesce(speeches.count_sittings_spoken, 0) as count_sittings_spoken,
+            coalesce(speeches.count_topics, 0) as count_topics,
+            coalesce(speeches.count_pri_questions, 0) as count_pri_questions,
+            coalesce(speeches.count_speeches, 0) as count_speeches,
+
+            -- readability-related
+            coalesce(speeches.count_words, 0) as count_words,
+            coalesce(speeches.count_sentences, 0) as count_sentences,
+            coalesce(speeches.count_syllables, 0) as count_syllables
+
+        from speeches
+        full join attendance using (parliament, year, month, member_name)
+    ),
+
+    enrich_member_party as (
+        select join_metrics.*, members.party as member_party
+        from join_metrics
+        left join {{ ref("dim_members") }} as members using (member_name)
+    ),
+
+    reorder_columns as (
+        select
+            parliament,
+            year,
+            month,
+            member_name,
+            member_party,
+            member_constituency,
+
+            count_sittings_total,
+            count_sittings_present,
+            count_sittings_spoken,
+            count_topics,
+            count_pri_questions,
+            count_speeches,
+
+            count_words,
+            count_sentences,
+            count_syllables
+        from enrich_member_party
+    )
+
+select *
+from reorder_columns
+order by member_name, parliament, year, month

--- a/models/agg/schema.yml
+++ b/models/agg/schema.yml
@@ -3,3 +3,5 @@ version: 2
 models:
     - name: agg_speech_metrics_by_member
       description: '{{ doc("agg_speech_metrics_by_member") }}'
+    - name: agg_pri_questions_topics_by_member
+      description: '{{ doc("agg_pri_questions_topics_by_member") }}'

--- a/models/agg/schema.yml
+++ b/models/agg/schema.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+    - name: agg_speech_metrics_by_member
+      description: '{{ doc("agg_speech_metrics_by_member") }}'

--- a/models/mart/mart_attendance.sql
+++ b/models/mart/mart_attendance.sql
@@ -16,7 +16,7 @@ with
             member_position as constituency,
             effective_from_date,
             coalesce(effective_to_date, current_date()) as effective_to_date
-        from {{ ref('fact_member_positions') }}
+        from {{ ref("fact_member_positions") }}
         where type = 'constituency'
     ),
 
@@ -39,9 +39,12 @@ with
         from attendance
         left join sittings on attendance.date = sittings.date
         left join members on attendance.member_name = members.member_name
-        left join member_constituency
+        left join
+            member_constituency
             on attendance.member_name = member_constituency.member_name
-            and attendance.date between member_constituency.effective_from_date and member_constituency.effective_to_date
+            and attendance.date
+            between member_constituency.effective_from_date
+            and member_constituency.effective_to_date
     )
 
 select *

--- a/models/mart/mart_attendance.sql
+++ b/models/mart/mart_attendance.sql
@@ -10,6 +10,16 @@ with
 
     members as (select member_name, party, gender from {{ ref("dim_members") }}),
 
+    member_constituency as (
+        select
+            member_name,
+            member_position as constituency,
+            effective_from_date,
+            coalesce(effective_to_date, current_date()) as effective_to_date
+        from {{ ref('fact_member_positions') }}
+        where type = 'constituency'
+    ),
+
     joined as (
         select
             -- metadata
@@ -21,6 +31,7 @@ with
             attendance.member_name,
             members.party as member_party,
             members.gender as member_gender,
+            member_constituency.constituency as member_constituency,
 
             -- attendance information
             attendance.is_present
@@ -28,6 +39,9 @@ with
         from attendance
         left join sittings on attendance.date = sittings.date
         left join members on attendance.member_name = members.member_name
+        left join member_constituency
+            on attendance.member_name = member_constituency.member_name
+            and attendance.date between member_constituency.effective_from_date and member_constituency.effective_to_date
     )
 
 select *

--- a/models/stg/stg_attendance.sql
+++ b/models/stg/stg_attendance.sql
@@ -8,7 +8,25 @@ with
             cast(is_present as bool) as is_present
         from {{ source("raw", "attendance") }}
         where member_name is not null
+    ),
+
+    standardise_member_name as (
+        select
+            * except (member_name),
+            -- mapping of names here:
+            -- https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/edit#gid=1498942254
+            coalesce(mapping.member_name, type_cast.member_name) as member_name
+        from type_cast
+        left join
+            {{ source("google_sheets", "member_name_mapping") }} as mapping
+            on mapping.possible_variation = type_cast.member_name
+    ),
+
+    filter_empty_member_name as (
+        select *
+        from standardise_member_name
+        where member_name != ''
     )
 
 select *
-from type_cast
+from filter_empty_member_name

--- a/models/stg/stg_attendance.sql
+++ b/models/stg/stg_attendance.sql
@@ -23,9 +23,7 @@ with
     ),
 
     filter_empty_member_name as (
-        select *
-        from standardise_member_name
-        where member_name != ''
+        select * from standardise_member_name where member_name != ''
     )
 
 select *


### PR DESCRIPTION
main changes:
* to replace aggregations required for streamlit (see [agg_data in streamlit](https://github.com/jeremychia/singapore-parliament-speeches-streamlit/blob/main/agg_data/__init__.py))
* performs computation once as part of the pipeline to reduce compute time needed on refresh

incidental:
* cleaning of member_names in stg_attendance
* adding constituencies to mart_attendance

to follow up:
* document new models
* refactor streamlit to use new tables