### PR TITLE
feat: add ethnicity information to dim members

### DIFF
--- a/docs/columns/member_ethnicity.md
+++ b/docs/columns/member_ethnicity.md
@@ -1,0 +1,5 @@
+{% docs member_ethnicity %}
+
+'Ethnicity' represents the ethnicity of the member (Chinese, Malay, Indian, or Others).
+
+{% enddocs %}

--- a/models/dim/dim_members.sql
+++ b/models/dim/dim_members.sql
@@ -20,7 +20,7 @@ with
     ethnicity as (
         select member_name, member_ethnicity
         from {{ ref("stg_gsheet_member_ethnicity") }}
-    )
+    ),
 
     full_name as (
         select member_name, member_name_website from {{ ref("stg_members_full_name") }}

--- a/models/dim/dim_members.sql
+++ b/models/dim/dim_members.sql
@@ -17,6 +17,11 @@ with
         from {{ ref("stg_members_year_of_birth") }}
     ),
 
+    ethnicity as (
+        select member_name, member_ethnicity
+        from {{ ref("stg_gsheet_member_ethnicity") }}
+    )
+
     full_name as (
         select member_name, member_name_website from {{ ref("stg_members_full_name") }}
     ),
@@ -62,6 +67,7 @@ with
         select
             agg.member_name,
             birth_year.member_birth_year,
+            ethnicity.member_ethnicity,
             seed.party,
             seed.gender,
             constituency.member_constituency as latest_member_constituency,
@@ -76,6 +82,7 @@ with
         from agg_attendance as agg
         left join seed_member as seed on agg.member_name = seed.member_name
         left join birth_year on agg.member_name = birth_year.member_name
+        left join ethnicity on agg.member_name = ethnicity.member_name
         left join full_name on agg.member_name = full_name.member_name
         left join image on agg.member_name = image.member_name
         left join constituency on agg.member_name = constituency.member_name

--- a/models/dim/schema.yml
+++ b/models/dim/schema.yml
@@ -13,6 +13,8 @@ models:
           description: '{{ doc("member_party") }}'
         - name: gender
           description: '{{ doc("member_gender") }}'
+        - name: member_ethnicity
+          description: '{{ doc("member_ethnicity") }}'
         - name: earliest_sitting
           description: '{{ doc("member_earliest_sitting") }}'
         - name: latest_sitting

--- a/models/fact/fact_speeches.sql
+++ b/models/fact/fact_speeches.sql
@@ -32,7 +32,7 @@ with
     */
     flag_speech_characteristics as (
         select
-            * except(percentile10_count_words, percentile90_count_words),
+            * except (percentile10_count_words, percentile90_count_words),
             count_words <= percentile10_count_words as is_short_speech,
             count_words >= percentile90_count_words as is_long_speech,
             contains_substr(text, 'vernacular speech') as is_vernacular_speech,

--- a/models/mart/mart_attendance.sql
+++ b/models/mart/mart_attendance.sql
@@ -8,7 +8,9 @@ with
 
     sittings as (select date, parliament, session from {{ ref("fact_sittings") }}),
 
-    members as (select member_name, party, gender from {{ ref("dim_members") }}),
+    members as (
+        select member_name, party, gender, ethnicity from {{ ref("dim_members") }}
+    ),
 
     member_constituency as (
         select
@@ -31,6 +33,7 @@ with
             attendance.member_name,
             members.party as member_party,
             members.gender as member_gender,
+            members.member_ethnicity as member_ethnicity,
             member_constituency.constituency as member_constituency,
 
             -- attendance information

--- a/models/mart/mart_attendance.sql
+++ b/models/mart/mart_attendance.sql
@@ -9,7 +9,8 @@ with
     sittings as (select date, parliament, session from {{ ref("fact_sittings") }}),
 
     members as (
-        select member_name, party, gender, ethnicity from {{ ref("dim_members") }}
+        select member_name, party, gender, member_ethnicity
+        from {{ ref("dim_members") }}
     ),
 
     member_constituency as (

--- a/models/mart/mart_speeches.sql
+++ b/models/mart/mart_speeches.sql
@@ -37,7 +37,8 @@ with
     ),
 
     members as (
-        select member_name, party, gender, ethnicity from {{ ref("dim_members") }}
+        select member_name, party, gender, member_ethnicity
+        from {{ ref("dim_members") }}
     ),
 
     constituencies as (

--- a/models/mart/mart_speeches.sql
+++ b/models/mart/mart_speeches.sql
@@ -36,7 +36,7 @@ with
         from {{ ref("fact_sittings") }}
     ),
 
-    members as (select member_name, party, gender from {{ ref("dim_members") }}),
+    members as (select member_name, party, gender, ethnicity from {{ ref("dim_members") }}),
 
     constituencies as (
         select
@@ -68,6 +68,7 @@ with
             speeches.member_name,
             members.party as member_party,
             members.gender as member_gender,
+            members.member_ethnicity as member_ethnicity,
             case
                 when members.party = 'NMP'
                 then 'Nominated Member of Parliament'

--- a/models/mart/mart_speeches.sql
+++ b/models/mart/mart_speeches.sql
@@ -36,7 +36,9 @@ with
         from {{ ref("fact_sittings") }}
     ),
 
-    members as (select member_name, party, gender, ethnicity from {{ ref("dim_members") }}),
+    members as (
+        select member_name, party, gender, ethnicity from {{ ref("dim_members") }}
+    ),
 
     constituencies as (
         select

--- a/models/mart/schema.yml
+++ b/models/mart/schema.yml
@@ -51,6 +51,8 @@ models:
           description: '{{ doc("member_party") }}'
         - name: member_gender
           description: '{{ doc("member_gender") }}'
+        - name: member_ethnicity
+          description: '{{ doc("member_ethnicity") }}'
         - name: topic_title
           description: '{{ doc("topic_title") }}'
         - name: topic_type

--- a/models/mart/schema.yml
+++ b/models/mart/schema.yml
@@ -21,6 +21,8 @@ models:
           description: '{{ doc("member_party") }}'
         - name: member_gender
           description: '{{ doc("member_gender") }}'
+        - name: member_ethnicity
+          description: '{{ doc("member_ethnicity") }}'
         - name: is_present
           description: '{{ doc("is_present") }}'
 

--- a/models/stg/google_sheet/schema.yml
+++ b/models/stg/google_sheet/schema.yml
@@ -30,6 +30,22 @@ sources:
             data_type: STRING
           - name: accessed_at
             data_type: STRING
+      - name: ethnicity
+        description: >
+          Ethnicity that were manually filled.
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/']
+            sheet_range: members_ethnicity
+            skip_leading_rows: 1
+        columns:
+          - name: member_name
+            data_type: STRING
+          - name: ethnicity
+            data_type: STRING
+          - name: is_ethnicity_certain
+            data_type: STRING
       - name: year_of_birth
         description: >
           Year of Birth Data that were manually filled.

--- a/models/stg/google_sheet/stg_gsheet_member_ethnicity.sql
+++ b/models/stg/google_sheet/stg_gsheet_member_ethnicity.sql
@@ -1,0 +1,5 @@
+with
+    source as (select * from {{ source("google_sheets", "ethnicity") }}),
+    renamed as (select member_name, ethnicity as member_ethnicity from source)
+select *
+from renamed


### PR DESCRIPTION
this PR exposes ethnicity information to dim_members, and includes this information in attendance and speeches. the manual input for a member's ethnicity is stored in this [google sheet](https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/edit?gid=455429087#gid=455429087).

the following commands were run:

to delete the original table
```sql
drop table if exists `singapore-parliament-speeches.prod_dim.dim_members_ethnicity`;
```

to stage as an external source
```sh
dbt run-operation stage_external_sources --vars "ext_full_refresh: true" --args "select: google_sheets.ethnicity"
```