### PR TITLE
docs: improve documentation for parliamentary speeches

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -54,6 +54,10 @@ models:
       +materialized: view
       +schema: stg
       +tags: staging
+    agg:
+      +materialized: table
+      +schema: agg
+      +tags: aggregates
 
 seeds:
   +schema: seeds

--- a/docs/columns/bill_day_diff_first_second_reading.md
+++ b/docs/columns/bill_day_diff_first_second_reading.md
@@ -1,0 +1,5 @@
+{% docs bill_day_diff_first_second_reading %}
+
+Difference between first_reading_date and second_reading_date.
+
+{% enddocs %}

--- a/docs/columns/bill_day_diff_first_second_reading.md
+++ b/docs/columns/bill_day_diff_first_second_reading.md
@@ -1,5 +1,5 @@
 {% docs bill_day_diff_first_second_reading %}
 
-Difference between first_reading_date and second_reading_date.
+Difference in days between first_reading_date and second_reading_date.
 
 {% enddocs %}

--- a/docs/columns/bill_day_diff_second_third_reading.md
+++ b/docs/columns/bill_day_diff_second_third_reading.md
@@ -1,5 +1,5 @@
 {% docs bill_day_diff_second_third_reading %}
 
-Difference between second_reading_date and third_reading_date (usually 0).
+Difference in days between second_reading_date and third_reading_date (usually 0).
 
 {% enddocs %}

--- a/docs/columns/bill_day_diff_second_third_reading.md
+++ b/docs/columns/bill_day_diff_second_third_reading.md
@@ -1,0 +1,5 @@
+{% docs bill_day_diff_second_third_reading %}
+
+Difference between second_reading_date and third_reading_date (usually 0).
+
+{% enddocs %}

--- a/docs/columns/bill_day_diff_third_reading_passed.md
+++ b/docs/columns/bill_day_diff_third_reading_passed.md
@@ -1,5 +1,5 @@
 {% docs bill_day_diff_third_reading_passed %}
 
-Difference between third_reading_date and passed_date.
+Difference in days between third_reading_date and passed_date.
 
 {% enddocs %}

--- a/docs/columns/bill_day_diff_third_reading_passed.md
+++ b/docs/columns/bill_day_diff_third_reading_passed.md
@@ -1,0 +1,5 @@
+{% docs bill_day_diff_third_reading_passed %}
+
+Difference between third_reading_date and passed_date.
+
+{% enddocs %}

--- a/docs/columns/bill_first_reading_date.md
+++ b/docs/columns/bill_first_reading_date.md
@@ -1,5 +1,5 @@
 {% docs bill_first_reading_date %}
 
-Date bill was first introduced to parliament. Members will thereafter have time to read the bill.
+The date bill was first introduced to parliament. Members will thereafter have time to read the bill. Date format: YYYY-MM-DD.
 
 {% enddocs %}

--- a/docs/columns/bill_first_reading_date.md
+++ b/docs/columns/bill_first_reading_date.md
@@ -1,0 +1,5 @@
+{% docs bill_first_reading_date %}
+
+Date bill was first introduced to parliament. Members will thereafter have time to read the bill.
+
+{% enddocs %}

--- a/docs/columns/bill_number.md
+++ b/docs/columns/bill_number.md
@@ -1,0 +1,5 @@
+{% docs bill_number %}
+
+Unique identifier for each bill.
+
+{% enddocs %}

--- a/docs/columns/bill_passed_date.md
+++ b/docs/columns/bill_passed_date.md
@@ -1,0 +1,5 @@
+{% docs bill_passed_date %}
+
+Date bill was passed in parliament. Thereafter, needs President's Assent to become law.
+
+{% enddocs %}

--- a/docs/columns/bill_passed_date.md
+++ b/docs/columns/bill_passed_date.md
@@ -1,5 +1,5 @@
 {% docs bill_passed_date %}
 
-Date bill was passed in parliament. Thereafter, needs President's Assent to become law.
+The date bill was passed in parliament. Thereafter, needs President's Assent to become law. Date format: YYYY-MM-DD.
 
 {% enddocs %}

--- a/docs/columns/bill_pdf_link.md
+++ b/docs/columns/bill_pdf_link.md
@@ -1,0 +1,5 @@
+{% docs bill_pdf_link %}
+
+PDF of changes in the bill.
+
+{% enddocs %}

--- a/docs/columns/bill_second_reading_date.md
+++ b/docs/columns/bill_second_reading_date.md
@@ -1,0 +1,5 @@
+{% docs bill_second_reading_date %}
+
+Date bill was subsequently introduced to parliament. This is typically when it is debated and/or amendments are proposed.
+
+{% enddocs %}

--- a/docs/columns/bill_second_reading_date.md
+++ b/docs/columns/bill_second_reading_date.md
@@ -1,5 +1,5 @@
 {% docs bill_second_reading_date %}
 
-Date bill was subsequently introduced to parliament. This is typically when it is debated and/or amendments are proposed.
+The date bill was subsequently introduced to parliament. This is typically when it is debated and/or amendments are proposed. Date format: YYYY-MM-DD.
 
 {% enddocs %}

--- a/docs/columns/bill_third_reading_date.md
+++ b/docs/columns/bill_third_reading_date.md
@@ -1,0 +1,5 @@
+{% docs bill_third_reading_date %}
+
+Date bill was read for the third time to parliament. This is typically when there are amendments.
+
+{% enddocs %}

--- a/docs/columns/bill_third_reading_date.md
+++ b/docs/columns/bill_third_reading_date.md
@@ -1,5 +1,5 @@
 {% docs bill_third_reading_date %}
 
-Date bill was read for the third time to parliament. This is typically when there are amendments.
+The date bill was read for the third time to parliament. This is typically when there are amendments. Date format: YYYY-MM-DD.
 
 {% enddocs %}

--- a/docs/columns/count_characters.md
+++ b/docs/columns/count_characters.md
@@ -1,5 +1,5 @@
 {% docs count_characters %}
 
-Count of number of characters (alphabetic characters only) within a given speech. i.e. Cumulative lenght of all words within the speech.
+Number of alphabetic characters within a given speech.
 
 {% enddocs %}

--- a/docs/columns/count_sentences.md
+++ b/docs/columns/count_sentences.md
@@ -1,5 +1,5 @@
 {% docs count_sentences %}
 
-Count of number of sentences within a given speech. Detected by, for example, periods, question marks, etc.
+Number of sentences within a given speech. These are detected by periods, question marks, exclamation marks.
 
 {% enddocs %}

--- a/docs/columns/count_sentences.md
+++ b/docs/columns/count_sentences.md
@@ -1,5 +1,5 @@
 {% docs count_sentences %}
 
-Number of sentences within a given speech. These are detected by periods, question marks, exclamation marks.
+Number of sentences in a given speech, where sentences are defined as continuous blocks of text ending with periods, question marks, or exclamation marks.
 
 {% enddocs %}

--- a/docs/columns/count_syllables.md
+++ b/docs/columns/count_syllables.md
@@ -1,6 +1,6 @@
 {% docs count_syllables %}
 
-Count of number of syllables within a given speech.
+Number of syllables within a given speech.
 Calculated using a heuristic method. See the [`count_syllables(word)`](https://github.com/jeremychia/singapore-parliament-speeches/blob/aab0ec3cf820a768c40e3a5ad22aa075640616d1/scripts/transform/speeches.py#L71C5-L71C20) function.
 
 {% enddocs %}

--- a/docs/columns/count_words.md
+++ b/docs/columns/count_words.md
@@ -1,5 +1,5 @@
 {% docs count_words %}
 
-Count of number of words within a given speech.
+Number of words within a given speech.
 
 {% enddocs %}

--- a/docs/columns/date.md
+++ b/docs/columns/date.md
@@ -1,5 +1,5 @@
 {% docs date %}
 
-The 'Date' field represents the specific date on which parliamentary sitting had happened or when the speech was delivered.
+When parliamentary sitting had happened or when the speech was delivered.
 
 {% enddocs %}

--- a/docs/columns/date.md
+++ b/docs/columns/date.md
@@ -1,5 +1,5 @@
 {% docs date %}
 
-When parliamentary sitting had happened or when the speech was delivered.
+When parliamentary sitting had happened or when the speech was delivered. Date format: YYYY-MM-DD.
 
 {% enddocs %}

--- a/docs/columns/datetime.md
+++ b/docs/columns/datetime.md
@@ -1,5 +1,5 @@
 {% docs datetime %}
 
-'Datetime' represents the specific date and time when a parliamentary sitting commenced.
+When a parliamentary sitting commenced for a given day.
 
 {% enddocs %}

--- a/docs/columns/effective_from_date.md
+++ b/docs/columns/effective_from_date.md
@@ -1,5 +1,5 @@
 {% docs effective_from_date %}
 
-Date which the appointment is effective from.
+Date which the appointment is effective from. Date format: YYYY-MM-DD
 
 {% enddocs %}

--- a/docs/columns/effective_from_date.md
+++ b/docs/columns/effective_from_date.md
@@ -1,5 +1,5 @@
 {% docs effective_from_date %}
 
-In relation to a position, the date from which the appointment is effective from.
+Date which the appointment is effective from.
 
 {% enddocs %}

--- a/docs/columns/effective_to_date.md
+++ b/docs/columns/effective_to_date.md
@@ -1,5 +1,5 @@
 {% docs effective_to_date %}
 
-Date which the appointment is effective to.
+Date which the appointment is effective to. Date format: YYYY-MM-DD
 
 {% enddocs %}

--- a/docs/columns/effective_to_date.md
+++ b/docs/columns/effective_to_date.md
@@ -1,5 +1,5 @@
 {% docs effective_to_date %}
 
-In relation to a position, the date from which the appointment is effective to.
+Date which the appointment is effective to.
 
 {% enddocs %}

--- a/docs/columns/is_latest_position.md
+++ b/docs/columns/is_latest_position.md
@@ -1,8 +1,5 @@
 {% docs is_latest_position %}
 
-True for latest position.
-
-CURRENT MPs: their current appointment (effective to date is null).
-FORMER MPs: last held appointment before stepping down.
+Boolean value. True if the MP is currently holding this appointment, or if this was the last appointment the MP held before stepping down. False otherwise.
 
 {% enddocs %}

--- a/docs/columns/is_latest_position.md
+++ b/docs/columns/is_latest_position.md
@@ -1,7 +1,8 @@
 {% docs is_latest_position %}
 
-In relation to a position, whether it is a latest position.
-For current MPs, this reflects their current appointment (effective to date is null).
-For former MPs, this reflects the latest held appointment before stepping down.
+True for latest position.
+
+CURRENT MPs: their current appointment (effective to date is null).
+FORMER MPs: last held appointment before stepping down.
 
 {% enddocs %}

--- a/docs/columns/is_long_speech.md
+++ b/docs/columns/is_long_speech.md
@@ -1,6 +1,6 @@
 {% docs is_long_speech %}
 
-Indicates if the speech is considered long. TRUE if the word count is at or above the 90th percentile, otherwise FALSE.
+TRUE if the word count is at or above the 90th percentile of all speeches.
 
 {% enddocs %}
 

--- a/docs/columns/is_long_speech.md
+++ b/docs/columns/is_long_speech.md
@@ -1,6 +1,6 @@
 {% docs is_long_speech %}
 
-TRUE if the word count is at or above the 90th percentile of all speeches.
+Boolean value. TRUE if the word count is at or above the 90th percentile of all speeches. False otherwise.
 
 {% enddocs %}
 

--- a/docs/columns/is_present.md
+++ b/docs/columns/is_present.md
@@ -1,5 +1,5 @@
 {% docs is_present %}
 
-TRUE if member was present for that day's sitting.
+Boolean value. TRUE if member was present for that day's sitting. False otherwise.
 
 {% enddocs %}

--- a/docs/columns/is_present.md
+++ b/docs/columns/is_present.md
@@ -1,5 +1,5 @@
 {% docs is_present %}
 
-'Is Present' is a boolean field indicating whether the MP was present on a particular date. A value of 'true' signifies presence, while 'false' indicates absence.
+TRUE if member was present for that day's sitting.
 
 {% enddocs %}

--- a/docs/columns/is_primary_question.md
+++ b/docs/columns/is_primary_question.md
@@ -1,0 +1,11 @@
+{% docs is_primary_question %}
+
+TRUE if was a parliamentary question posed. 
+
+Derived from first looking at: 
+* Written Answers to Questions (WA), Written Answer to Question for Oral Answer not Answered by End of Question Time (WANA), or Oral Answers to Questions (OA).
+* Where question was asked to a political office holder.
+
+{% enddocs %}
+
+

--- a/docs/columns/is_primary_question.md
+++ b/docs/columns/is_primary_question.md
@@ -1,6 +1,6 @@
 {% docs is_primary_question %}
 
-TRUE if was a parliamentary question posed. 
+Boolean value. TRUE if was a parliamentary question posed. False otherwise.
 
 Derived from first looking at: 
 * Written Answers to Questions (WA), Written Answer to Question for Oral Answer not Answered by End of Question Time (WANA), or Oral Answers to Questions (OA).

--- a/docs/columns/is_short_speech.md
+++ b/docs/columns/is_short_speech.md
@@ -1,6 +1,6 @@
 {% docs is_short_speech %}
 
-Indicates if the speech is considered short. TRUE if the word count is at or below the 10th percentile, otherwise FALSE.
+TRUE if the word count is at or below the 10th percentile of all speeches.
 
 {% enddocs %}
 

--- a/docs/columns/is_short_speech.md
+++ b/docs/columns/is_short_speech.md
@@ -1,6 +1,6 @@
 {% docs is_short_speech %}
 
-TRUE if the word count is at or below the 10th percentile of all speeches.
+Boolean value. TRUE if the word count is at or below the 10th percentile of all speeches. False otherwise.
 
 {% enddocs %}
 

--- a/docs/columns/is_topic_constitutional.md
+++ b/docs/columns/is_topic_constitutional.md
@@ -1,6 +1,6 @@
 {% docs is_topic_constitutional %}
 
-TRUE if topic concerns a constitution amendment.
+Boolean value. TRUE if topic concerns a constitution amendment. False otherwise.
 
 This applies only if:
 

--- a/docs/columns/is_topic_constitutional.md
+++ b/docs/columns/is_topic_constitutional.md
@@ -1,6 +1,6 @@
 {% docs is_topic_constitutional %}
 
-'Is Topic Constitutional' is a boolean field indicating whether the topic concerns a constitution amendment.
+TRUE if topic concerns a constitution amendment.
 
 This applies only if:
 

--- a/docs/columns/is_topic_procedural.md
+++ b/docs/columns/is_topic_procedural.md
@@ -1,6 +1,6 @@
 {% docs is_topic_procedural %}
 
-'Is Topic Procedural' is a boolean field indicating whether the topic concerns a procedural statement, and therefore should be considered excluded from the speech count..
+TRUE if topic concerns a procedural statement, and therefore should be considered excluded from the speech count.
 
 This applies only if:
 

--- a/docs/columns/is_topic_procedural.md
+++ b/docs/columns/is_topic_procedural.md
@@ -1,6 +1,6 @@
 {% docs is_topic_procedural %}
 
-TRUE if topic concerns a procedural statement, and therefore should be considered excluded from the speech count.
+Boolean value. TRUE if topic concerns a procedural statement, and therefore should be considered excluded from the speech count. False otherwise.
 
 This applies only if:
 

--- a/docs/columns/is_vernacular_speech.md
+++ b/docs/columns/is_vernacular_speech.md
@@ -1,5 +1,5 @@
 {% docs is_vernacular_speech %}
 
-Indicates if the speech contains the phrase "vernacular speech". TRUE if it does, otherwise FALSE.
+TRUE if speeches contains phrase "vernacular speech".
 
 {% enddocs %}

--- a/docs/columns/is_vernacular_speech.md
+++ b/docs/columns/is_vernacular_speech.md
@@ -1,5 +1,5 @@
 {% docs is_vernacular_speech %}
 
-TRUE if speeches contains phrase "vernacular speech".
+Boolean value. TRUE if speeches contains phrase "vernacular speech". False otherwise.
 
 {% enddocs %}

--- a/docs/columns/member_appointments.md
+++ b/docs/columns/member_appointments.md
@@ -1,0 +1,5 @@
+{% docs member_appointments %}
+
+Political appointments.
+
+{% enddocs %}

--- a/docs/columns/member_birth_year.md
+++ b/docs/columns/member_birth_year.md
@@ -1,0 +1,5 @@
+{% docs member_birth_year %}
+
+Birth year.
+
+{% enddocs %}

--- a/docs/columns/member_constituency.md
+++ b/docs/columns/member_constituency.md
@@ -1,0 +1,5 @@
+{% docs member_constituency %}
+
+Single-member Group-representative (SMC/GRC) Constituency which member represents.
+
+{% enddocs %}

--- a/docs/columns/member_count_concurrent_appointments.md
+++ b/docs/columns/member_count_concurrent_appointments.md
@@ -1,0 +1,5 @@
+{% docs member_count_concurrent_appointments %}
+
+Number of concurrent political appointments at any one point in time.
+
+{% enddocs %}

--- a/docs/columns/member_count_pri_questions.md
+++ b/docs/columns/member_count_pri_questions.md
@@ -1,0 +1,5 @@
+{% docs member_count_pri_questions %}
+
+Number of primary questions (see is_primary_question for definition).
+
+{% enddocs %}

--- a/docs/columns/member_count_sittings_present.md
+++ b/docs/columns/member_count_sittings_present.md
@@ -1,5 +1,5 @@
 {% docs member_count_sittings_present %}
 
-'Count of Sittings Present' indicates the total number of sittings the member attended.
+Number of sittings the member attended (was present for).
 
 {% enddocs %}

--- a/docs/columns/member_count_sittings_present.md
+++ b/docs/columns/member_count_sittings_present.md
@@ -1,5 +1,5 @@
 {% docs member_count_sittings_present %}
 
-Number of sittings the member attended (was present for).
+Number of sittings the member attended.
 
 {% enddocs %}

--- a/docs/columns/member_count_sittings_spoken.md
+++ b/docs/columns/member_count_sittings_spoken.md
@@ -1,0 +1,5 @@
+{% docs member_count_sittings_spoken %}
+
+Number of parliamentary sittings during which the member made a speech/asked a question.
+
+{% enddocs %}

--- a/docs/columns/member_count_sittings_spoken.md
+++ b/docs/columns/member_count_sittings_spoken.md
@@ -1,5 +1,5 @@
 {% docs member_count_sittings_spoken %}
 
-Number of parliamentary sittings during which the member made a speech/asked a question.
+Number of parliamentary sittings during which the member made a speech or asked a question.
 
 {% enddocs %}

--- a/docs/columns/member_count_sittings_total.md
+++ b/docs/columns/member_count_sittings_total.md
@@ -1,5 +1,5 @@
 {% docs member_count_sittings_total %}
 
-'Count of Total Sittings' represents the total number of parliamentary sittings during which the member was eligible to participate.
+Number of parliamentary sittings during which the member was eligible to participate.
 
 {% enddocs %}

--- a/docs/columns/member_count_speeches.md
+++ b/docs/columns/member_count_speeches.md
@@ -1,0 +1,5 @@
+{% docs member_count_speeches %}
+
+Number of distinct speech IDs
+
+{% enddocs %}

--- a/docs/columns/member_count_topics.md
+++ b/docs/columns/member_count_topics.md
@@ -1,0 +1,5 @@
+{% docs member_count_topics %}
+
+Number of distinct topic IDs
+
+{% enddocs %}

--- a/docs/columns/member_earliest_sitting.md
+++ b/docs/columns/member_earliest_sitting.md
@@ -1,6 +1,6 @@
 {% docs member_earliest_sitting %}
 
-'Earliest Sitting' denotes the date of the member's earliest recorded parliamentary sitting.
-The earliest sitting in this dataset is 2012-09-10.
+Member's earliest recorded parliamentary sitting 
+Note: The earliest sitting in this dataset is 2012-09-10.
 
 {% enddocs %}

--- a/docs/columns/member_ethnicity.md
+++ b/docs/columns/member_ethnicity.md
@@ -1,5 +1,5 @@
 {% docs member_ethnicity %}
 
-'Ethnicity' represents the ethnicity of the member (Chinese, Malay, Indian, or Others).
+Ethnicity of the member (Chinese, Malay, Indian, or Others).
 
 {% enddocs %}

--- a/docs/columns/member_gender.md
+++ b/docs/columns/member_gender.md
@@ -1,5 +1,5 @@
 {% docs member_gender %}
 
-'Gender' represents the gender of the member (M for Male, F for Female).
+Gender of the member (M for Male, F for Female).
 
 {% enddocs %}

--- a/docs/columns/member_image_link.md
+++ b/docs/columns/member_image_link.md
@@ -1,0 +1,5 @@
+{% docs member_image_link %}
+
+Link to portrait image.
+
+{% enddocs %}

--- a/docs/columns/member_latest_member_appointments.md
+++ b/docs/columns/member_latest_member_appointments.md
@@ -1,0 +1,5 @@
+{% docs member_latest_member_appointments %}
+
+Current or last (for former MPs) political appointment(s).
+
+{% enddocs %}

--- a/docs/columns/member_latest_member_committees.md
+++ b/docs/columns/member_latest_member_committees.md
@@ -1,0 +1,5 @@
+{% docs member_latest_member_committees %}
+
+Current or last (for former MPs) parliamentary committee membership(s).
+
+{% enddocs %}

--- a/docs/columns/member_latest_member_constituency.md
+++ b/docs/columns/member_latest_member_constituency.md
@@ -1,0 +1,5 @@
+{% docs member_latest_member_constituency %}
+
+Current or last (for former MPs) constitutency represented.
+
+{% enddocs %}

--- a/docs/columns/member_latest_sitting.md
+++ b/docs/columns/member_latest_sitting.md
@@ -1,5 +1,5 @@
 {% docs member_latest_sitting %}
 
-'Latest Sitting' represents the date of the member's latest recorded parliamentary sitting.
+Member's latest recorded parliamentary sitting.
 
 {% enddocs %}

--- a/docs/columns/member_name.md
+++ b/docs/columns/member_name.md
@@ -1,5 +1,5 @@
 {% docs member_name %}
 
-'Member Name' refers to the full name of the Member of Parliament (MP) whose attendance is being recorded.
+Full name of the Member of Parliament (MP) whose attendance is being recorded.
 
 {% enddocs %}

--- a/docs/columns/member_name_website.md
+++ b/docs/columns/member_name_website.md
@@ -1,0 +1,5 @@
+{% docs member_name_website %}
+
+MP's name for parliament's website
+
+{% enddocs %}

--- a/docs/columns/member_party.md
+++ b/docs/columns/member_party.md
@@ -1,6 +1,6 @@
 {% docs member_party %}
 
-'Party' indicates the political party or designation of the member.
+The political party or designation of the member.
 
 | Acronym |                 Party                 |
 | ------- | ------------------------------------- |

--- a/docs/columns/member_position.md
+++ b/docs/columns/member_position.md
@@ -1,5 +1,5 @@
 {% docs member_position %}
 
-Refers to the constitutency, political appointment, or select committee participation.
+Constitutency, political appointment, or select committee participation.
 
 {% enddocs %}

--- a/docs/columns/ministry_addressed.md
+++ b/docs/columns/ministry_addressed.md
@@ -1,0 +1,5 @@
+{% docs ministry_addressed %}
+
+Ministry which question was addressed to. Derived from which minister the question was addressed to.
+
+{% enddocs %}

--- a/docs/columns/ministry_addressed.md
+++ b/docs/columns/ministry_addressed.md
@@ -1,5 +1,5 @@
 {% docs ministry_addressed %}
 
-Ministry which question was addressed to. Derived from which minister the question was addressed to.
+Ministry which question was addressed to, derived from which minister the question was addressed to.
 
 {% enddocs %}

--- a/docs/columns/month.md
+++ b/docs/columns/month.md
@@ -1,0 +1,5 @@
+{% docs month %}
+
+Month parliamentary sitting had happened or when the speech was delivered.
+
+{% enddocs %}

--- a/docs/columns/parliament.md
+++ b/docs/columns/parliament.md
@@ -1,6 +1,6 @@
 {% docs parliament %}
 
-'Parliament' denotes the parliamentary term number. Each parliament meeting typically has two sessions.
+Parliamentary term number. Each parliament meeting typically has two sessions.
 
 |                              Parliamentary Term                               | Commencement | Prorogued  |
 | ----------------------------------------------------------------------------- | ------------ | ---------- |

--- a/docs/columns/session.md
+++ b/docs/columns/session.md
@@ -1,6 +1,6 @@
 {% docs session %}
 
-'Session' refers to the specific session within the parliamentary term. Each parliamentary term typically has two sessions.
+Specific session within the parliamentary term. Each parliamentary term typically has two sessions.
 
 | Parliament Term | Session |   Start    |    End     |
 | --------------- | ------- | ---------- | ---------- |

--- a/docs/columns/sittings.md
+++ b/docs/columns/sittings.md
@@ -1,5 +1,5 @@
 {% docs sittings %}
 
-'Sittings' refers to the order of sittings conducted during a particular parliamentary session. This is expected to be in a running sequence.
+Order of sittings conducted during a particular parliamentary session. This is expected to be in a running sequence.
 
 {% enddocs %}

--- a/docs/columns/speech_order.md
+++ b/docs/columns/speech_order.md
@@ -1,5 +1,5 @@
 {% docs speech_order %}
 
-Denotes the sequence or order in which the speech was delivered during the sitting.
+Order in which the speech was delivered during the sitting.
 
 {% enddocs %}

--- a/docs/columns/speech_order.md
+++ b/docs/columns/speech_order.md
@@ -1,5 +1,5 @@
 {% docs speech_order %}
 
-'Speech Order' denotes the sequence or order in which the speech was delivered during the sitting.
+Denotes the sequence or order in which the speech was delivered during the sitting.
 
 {% enddocs %}

--- a/docs/columns/speech_text.md
+++ b/docs/columns/speech_text.md
@@ -1,5 +1,5 @@
 {% docs speech_text %}
 
-'Speech Text' contains the actual content of the speech delivered in the Parliament.
+Contains the actual content of the speech delivered in Parliament.
 
 {% enddocs %}

--- a/docs/columns/speech_text.md
+++ b/docs/columns/speech_text.md
@@ -1,5 +1,5 @@
 {% docs speech_text %}
 
-Contains the actual content of the speech delivered in Parliament.
+Contains the raw content of the speech delivered in Parliament.
 
 {% enddocs %}

--- a/docs/columns/topic_id.md
+++ b/docs/columns/topic_id.md
@@ -1,5 +1,5 @@
 {% docs topic_id %}
 
-'Topic ID' represents the unique identifier for the topic or subject matter associated with the speech.
+Unique identifier for the topic or subject matter associated with the speech.
 
 {% enddocs %}

--- a/docs/columns/topic_order.md
+++ b/docs/columns/topic_order.md
@@ -1,5 +1,5 @@
 {% docs topic_order %}
 
-'Topic Order' denotes the sequence or order in which the topic was debated during the sitting.
+Denotes the sequence or order in which the topic was debated during the sitting.
 
 {% enddocs %}

--- a/docs/columns/topic_order.md
+++ b/docs/columns/topic_order.md
@@ -1,5 +1,5 @@
 {% docs topic_order %}
 
-Denotes the sequence or order in which the topic was debated during the sitting.
+Order in which the topic was debated during the sitting.
 
 {% enddocs %}

--- a/docs/columns/topic_title.md
+++ b/docs/columns/topic_title.md
@@ -1,5 +1,5 @@
 {% docs topic_title %}
 
-'Topic Title' represents the title or name of the parliamentary topic.
+Name header of the parliamentary topic.
 
 {% enddocs %}

--- a/docs/columns/topic_type.md
+++ b/docs/columns/topic_type.md
@@ -1,6 +1,6 @@
 {% docs topic_type %}
 
-'Section Type' (or Topic Type) indicates the type of section associated with the topic. This is the acronym.
+Indicates the type of section associated with the topic.
 
 'Section Type Name' indicates the full name of the section.
 

--- a/docs/columns/topic_type.md
+++ b/docs/columns/topic_type.md
@@ -1,6 +1,6 @@
 {% docs topic_type %}
 
-Indicates the type of section associated with the topic.
+Section type associated with the topic.
 
 'Section Type Name' indicates the full name of the section.
 

--- a/docs/columns/vernacular_speech_language.md
+++ b/docs/columns/vernacular_speech_language.md
@@ -1,6 +1,7 @@
 {% docs vernacular_speech_language %}
 
-Specifies the language of the vernacular speech. Extracts "mandarin", "malay", or "tamil" if the speech is vernacular, otherwise NULL.
+Specifies the language of the vernacular speech. 
+Extracts "mandarin", "malay", or "tamil" if the speech is vernacular, otherwise NULL.
 
 {% enddocs %}
 

--- a/docs/columns/vernacular_speech_language.md
+++ b/docs/columns/vernacular_speech_language.md
@@ -1,7 +1,8 @@
 {% docs vernacular_speech_language %}
 
-Specifies the language of the vernacular speech. 
-Extracts "mandarin", "malay", or "tamil" if the speech is vernacular, otherwise NULL.
+Language of the vernacular speech.
+
+Extracts "mandarin", "malay", or "tamil" where "vernacular speech" appears in the raw text, otherwise NULL.
 
 {% enddocs %}
 

--- a/docs/columns/year.md
+++ b/docs/columns/year.md
@@ -1,0 +1,5 @@
+{% docs year %}
+
+Year parliamentary sitting had happened or when the speech was delivered.
+
+{% enddocs %}

--- a/docs/models/agg_pri_questions_topics_by_member.md
+++ b/docs/models/agg_pri_questions_topics_by_member.md
@@ -1,5 +1,6 @@
 {% docs agg_pri_questions_topics_by_member %}
 
-TODO
+Summary of primary questions asked by member.
+Each row represents the count of questions asked by parliament, year, month, member name and ministry addressed.
 
 {% enddocs %}

--- a/docs/models/agg_speech_metrics_by_member.md
+++ b/docs/models/agg_speech_metrics_by_member.md
@@ -1,5 +1,6 @@
 {% docs agg_speech_metrics_by_member %}
 
-TODO
+Summary of speech metrics (e.g. number of words, sittings, topics) by member, parliament, year month.
+Each row represents an aggregation by parliament, member, year-month.
 
 {% enddocs %}

--- a/docs/models/models_attendance.md
+++ b/docs/models/models_attendance.md
@@ -2,4 +2,6 @@
 
 Provides detailed information about the attendance records of Members of Parliament (MPs) during various parliamentary sessions.
 
+Each row represents a member's attendance on a given date.
+
 {% enddocs %}

--- a/docs/models/models_bill_activity.md
+++ b/docs/models/models_bill_activity.md
@@ -4,4 +4,6 @@ Provides reading (e.g. 'First Reading', 'Second Reading' etc.) activity by bill 
 
 For how the reading (first, second, third) is distinguished, see the column documentation for 'reading'.
 
+Each row represents a bill and corresponding activity.
+
 {% enddocs %}

--- a/docs/models/models_bills.md
+++ b/docs/models/models_bills.md
@@ -4,4 +4,6 @@ Provides information on bills. Information available:
 
 * When the first, second, third reading for the respective bill was.
 
+Each row represents one bill.
+
 {% enddocs %}

--- a/docs/models/models_members.md
+++ b/docs/models/models_members.md
@@ -2,6 +2,6 @@
 
 Provides information about members of the parliament, including details such as member name, party affiliation, gender, earliest sitting, latest sitting, count of sittings present, and count of total sittings.
 
-Each row represents one model.
+Each row represents one Member of Parliament (MP).
  
 {% enddocs %}

--- a/docs/models/models_members.md
+++ b/docs/models/models_members.md
@@ -1,5 +1,7 @@
 {% docs models_members %}
 
 Provides information about members of the parliament, including details such as member name, party affiliation, gender, earliest sitting, latest sitting, count of sittings present, and count of total sittings.
+
+Each row represents one model.
  
 {% enddocs %}

--- a/docs/models/models_sittings.md
+++ b/docs/models/models_sittings.md
@@ -11,4 +11,6 @@ Provides detailed information about parliamentary sittings, including the date, 
 | 14              | 1       | 95         | 2020-08-24 | 2023-03-24 |
 | 14              | 2       | 95         | 2023-04-10 | Present    |
 
+Each row represents one sitting.
+
 {% enddocs %}

--- a/docs/models/models_speeches.md
+++ b/docs/models/models_speeches.md
@@ -1,5 +1,7 @@
 {% docs models_speeches %}
 
 Contains information about speeches delivered in the Singapore Parliament, including details such as speech ID, date, topic ID, speech order, member name, and the text of the speech.
+
+Each row represents one speech (speech_id).
  
 {% enddocs %}

--- a/docs/models/models_topics.md
+++ b/docs/models/models_topics.md
@@ -2,4 +2,6 @@
 
 Provides information about parliamentary topics, including details such as topic ID, date, topic order, title, and section type.
  
+Each row represents one topic (topic_id).
+
 {% enddocs %}

--- a/models/agg/schema.yml
+++ b/models/agg/schema.yml
@@ -3,5 +3,51 @@ version: 2
 models:
     - name: agg_speech_metrics_by_member
       description: '{{ doc("agg_speech_metrics_by_member") }}'
+      columns:
+        - name: parliament
+          description: '{{ doc("parliament") }}' 
+        - name: year
+          description: '{{ doc("year") }}' 
+        - name: month
+          description: '{{ doc("month") }}' 
+        - name: member_name
+          description: '{{ doc("member_name") }}' 
+        - name: member_party
+          description: '{{ doc("member_party") }}' 
+        - name: member_constituency
+          description: '{{ doc("member_constituency") }}' 
+        - name: count_sittings_total
+          description: '{{ doc("member_count_sittings_total") }}' 
+        - name: count_sittings_present
+          description: '{{ doc("member_count_sittings_present") }}' 
+        - name: count_sittings_spoken
+          description: '{{ doc("member_count_sittings_spoken") }}' 
+        - name: count_topics
+          description: '{{ doc("member_count_topics") }}' 
+        - name: count_pri_questions
+          description: '{{ doc("member_count_pri_questions") }}' 
+        - name: count_speeches
+          description: '{{ doc("member_count_speeches") }}' 
+        - name: count_words
+          description: '{{ doc("count_words") }}' 
+        - name: count_sentences
+          description: '{{ doc("count_sentences") }}' 
+        - name: count_syllables
+          description: '{{ doc("count_syllables") }}' 
     - name: agg_pri_questions_topics_by_member
       description: '{{ doc("agg_pri_questions_topics_by_member") }}'
+      columns:
+        - name: parliament
+          description: '{{ doc("parliament") }}' 
+        - name: year
+          description: '{{ doc("year") }}' 
+        - name: month
+          description: '{{ doc("month") }}' 
+        - name: member_name
+          description: '{{ doc("member_name") }}' 
+        - name: member_constituency
+          description: '{{ doc("member_constituency") }}' 
+        - name: ministry_addressed
+          description: '{{ doc("ministry_addressed") }}' 
+        - name: count_pri_questions
+          description: '{{ doc("member_count_pri_questions") }}' 

--- a/models/dim/schema.yml
+++ b/models/dim/schema.yml
@@ -23,6 +23,18 @@ models:
           description: '{{ doc("member_count_sittings_present") }}'
         - name: count_sittings_total
           description: '{{ doc("member_count_sittings_total") }}'
+        - name: member_birth_year
+          description: '{{ doc("member_birth_year") }}' 
+        - name: latest_member_constituency
+          description: '{{ doc("member_latest_member_constituency") }}' 
+        - name: latest_member_appointments
+          description: '{{ doc("member_latest_member_appointments") }}' 
+        - name: latest_member_committees
+          description: '{{ doc("member_latest_member_committees") }}' 
+        - name: member_name_website
+          description: '{{ doc("member_name_website") }}' 
+        - name: member_image_link
+          description: '{{ doc("member_image_link") }}' 
 
     - name: dim_topics
       description: '{{ doc("models_topics") }}'
@@ -54,6 +66,8 @@ models:
                   severity: warn
         - name: topic_group_name
           description: '{{ doc("topic_group_name") }}'
+        - name: topic_group_distribution
+          description: '{{ doc("topic_group_distribution") }}' 
         - name: is_topic_constitutional
           description: '{{ doc("is_topic_constitutional") }}'
         - name: is_topic_procedural

--- a/models/fact/schema.yml
+++ b/models/fact/schema.yml
@@ -34,6 +34,25 @@ models:
         - name: reading
           description: '{{ doc("reading") }}'
 
+    - name: fact_bills_introduced
+      description: 'From parliament website {{ doc("models_bills") }}'
+      columns:
+        - name: bill_number
+          description: '{{ doc("bill_number") }}' 
+          tests:
+            - not_null
+            - unique
+        - name: title
+          description: '{{ doc("topic_title") }}' 
+        - name: first_reading_date
+          description: '{{ doc("bill_first_reading_date") }}' 
+        - name: second_reading_date
+          description: '{{ doc("bill_second_reading_date") }}' 
+        - name: passed_date
+          description: '{{ doc("bill_passed_date") }}' 
+        - name: bill_pdf_link
+          description: '{{ doc("bill_pdf_link") }}' 
+
     - name: fact_member_positions
       description: '{{ doc("models_member_positions") }}'
       columns:
@@ -127,24 +146,3 @@ models:
           description: '{{ doc("is_vernacular_speech") }}'
         - name: vernacular_speech_language
           description: '{{ doc("vernacular_speech_language") }}'
-
-
-    - name: fact_bills_introduced
-      description: 'From parliament website {{ doc("models_bills") }}'
-      columns:
-        - name: bill_number
-          description: ''
-          tests:
-            - not_null
-            - unique
-        - name: title
-          description: ''
-        - name: first_reading_date
-          description: ''
-        - name: second_reading_date
-          description: ''
-        - name: passed_date
-          description: ''
-        - name: bill_pdf_link
-          description: ''
-

--- a/models/mart/schema.yml
+++ b/models/mart/schema.yml
@@ -25,6 +25,8 @@ models:
           description: '{{ doc("member_ethnicity") }}'
         - name: is_present
           description: '{{ doc("is_present") }}'
+        - name: member_constituency
+          description: '{{ doc("member_constituency") }}' 
 
     - name: mart_speeches
       description: '{{ doc("models_speeches") }}'
@@ -83,6 +85,16 @@ models:
           description: '{{ doc("is_vernacular_speech") }}'
         - name: vernacular_speech_language
           description: '{{ doc("vernacular_speech_language") }}'
+        - name: member_constituency
+          description: '{{ doc("member_constituency") }}' 
+        - name: member_appointments
+          description: '{{ doc("member_appointments") }}' 
+        - name: member_count_concurrent_appointments
+          description: '{{ doc("member_count_concurrent_appointments") }}' 
+        - name: is_primary_question
+          description: '{{ doc("is_primary_question") }}' 
+        - name: ministry_addressed
+          description: '{{ doc("ministry_addressed") }}' 
 
     - name: mart_bills
       description: '{{ doc("models_bills") }}'
@@ -96,17 +108,32 @@ models:
 
       columns:
         - name: bill_number
+          description: '{{ doc("bill_number") }}' 
           tests:
             - unique
         - name: year
+          description: '{{ doc("year") }}' 
+        - name: title
+          description: '{{ doc("topic_title") }}' 
         - name: first_reading_date
+          description: '{{ doc("bill_first_reading_date") }}' 
         - name: first_reading_topic
-        - name: day_diff_first_second_reading
+          description: '{{ doc("topic_id") }}. Correpsonds to that of the first reading.' 
         - name: second_reading_date
+          description: '{{ doc("bill_second_reading_date") }}' 
         - name: second_reading_topic
-        - name: day_diff_second_third_reading
+          description: '{{ doc("topic_id") }}. Correpsonds to that of the second reading.' 
         - name: third_reading_date
+          description: '{{ doc("bill_third_reading_date") }}' 
         - name: third_reading_topic
-        - name: day_diff_third_reading_passed
+          description: '{{ doc("topic_id") }}. Correpsonds to that of the third reading, if applicable.' 
         - name: passed_date
+          description: '{{ doc("bill_passed_date") }}' 
+        - name: day_diff_first_second_reading
+          description: '{{ doc("bill_day_diff_first_second_reading") }}' 
+        - name: day_diff_second_third_reading
+          description: '{{ doc("bill_day_diff_second_third_reading") }}' 
+        - name: day_diff_third_reading_passed
+          description: '{{ doc("bill_day_diff_third_reading_passed") }}' 
         - name: bill_pdf_link
+          description: '{{ doc("bill_pdf_link") }}' 


### PR DESCRIPTION
this PR aims to:

* revise existing docstrings for brevity (https://github.com/jeremychia/singapore-parliament-speeches-dbt/pull/31/commits/06ae498902ead9fc828165b2e4bd64d5f8f4dbc5)

* include missing descriptions for columns - this is only for models and fields which are related to parliamentary speeches
  * for aggregates (agg): (https://github.com/jeremychia/singapore-parliament-speeches-dbt/pull/31/commits/8a920e7632a548456d8dcc6a2d95a80d3b8fbedf)
  * for dimensions (dim): (https://github.com/jeremychia/singapore-parliament-speeches-dbt/pull/31/commits/ab6782fd0a3ebd8e5f6f8857e96bd93cad7d92e2)
  * for facts: (https://github.com/jeremychia/singapore-parliament-speeches-dbt/pull/31/commits/4d811aadb5cf63d093e9ac81abfd7a02d9036058)
  * for marts: (https://github.com/jeremychia/singapore-parliament-speeches-dbt/pull/31/commits/106e2d487dbac7da7773ff43674b19fdfba1ffdd)

* revise existing models to minimally include information on:
  * what can i find in here? (summary)
  * what does each row represent? (granularity)

* include missing descriptions for models (https://github.com/jeremychia/singapore-parliament-speeches-dbt/pull/31/commits/f49ecae1721256e865c5d4d224e2849a0fabe65e)

---

this is meant to help users find the information better.
where will the descriptions be visible?

in bigquery:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/a356d6e3-f528-434c-91b4-233c125caf7a">


in [dbt documentation](https://jeremychia.github.io/singapore-parliament-speeches-dbt/#!/overview):
<img width="600" alt="image" src="https://github.com/user-attachments/assets/2af22bdf-4762-443e-8706-6ea11e165e75">


---

columns which are missing descriptions can be identified using this query which uses the column field paths metadata (see [google cloud docs](https://cloud.google.com/bigquery/docs/information-schema-column-field-paths)):

```sql
with
    union_information_schema as (
        select table_name, field_path, description
        from
            `singapore-parliament-speeches.prod_agg.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`
        where description = '' or description is null
        union all
        select table_name, field_path, description
        from
            `singapore-parliament-speeches.prod_dim.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`
        where description = '' or description is null
        union all
        select table_name, field_path, description
        from
            `singapore-parliament-speeches.prod_fact.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`
        where description = '' or description is null
        union all
        select table_name, field_path, description
        from
            `singapore-parliament-speeches.prod_mart.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`
        where description = '' or description is null
        union all
        select table_name, field_path, description
        from
            `singapore-parliament-speeches.prod_mart_prep.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`
        where description = '' or description is null
        union all
        select table_name, field_path, description
        from
            `singapore-parliament-speeches.prod_stg.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS`
        where description = '' or description is null
    )
select *
from union_information_schema
order by 1
```