### PR TITLE
Amend members information

### DIFF
--- a/models/agg/agg_speech_metrics_by_member.sql
+++ b/models/agg/agg_speech_metrics_by_member.sql
@@ -70,9 +70,11 @@ with
     ),
 
     enrich_member_party as (
-        select join_metrics.*, members.party as member_party
+        select join_metrics.*, 
+        members.party as member_party
         from join_metrics
-        left join {{ ref("dim_members") }} as members using (member_name)
+        left join {{ ref("stg_gsheet_member_party") }} as members 
+        using (member_name, parliament)
     ),
 
     reorder_columns as (

--- a/models/dashboard/dash_demographics.sql
+++ b/models/dashboard/dash_demographics.sql
@@ -1,15 +1,15 @@
 with
     get_demographics as (
         select
-            member_name,
-            parliament,
-            party as member_party,
-            member_constituency,
-            member_ethnicity,
-            gender,
-            member_birth_year,
-            extract(year from first_parl_date) - member_birth_year as year_age_entered
-        from {{ ref("dim_members") }}
+            members.member_name,
+            constituency.parliament,
+            party.party,
+            constituency.member_constituency,
+            members.member_ethnicity,
+            members.gender,
+            members.member_birth_year,
+            extract(year from constituency.first_parl_date) - members.member_birth_year as year_age_entered
+        from {{ ref("dim_members") }} as members
         left join
             (
                 select
@@ -20,7 +20,10 @@ with
                 from {{ ref("mart_attendance") }}
                 where member_constituency is not null
                 group by member_name, parliament, member_constituency
-            ) using (member_name)
+            ) as constituency using (member_name)
+        left join {{ ref("stg_gsheet_member_party") }} as party
+        on members.member_name = party.member_name
+        and constituency.parliament = party.parliament
         order by member_name, parliament
     )
 select *

--- a/models/dim/dim_members.sql
+++ b/models/dim/dim_members.sql
@@ -9,7 +9,7 @@ with
     ),
 
     gender as (
-        select mp_name as member_name, gender from {{ ref("stg_gsheet_member_gender") }}
+        select member_name, gender from {{ ref("stg_gsheet_member_gender") }}
     ),
 
     birth_year as (

--- a/models/dim/dim_members.sql
+++ b/models/dim/dim_members.sql
@@ -115,7 +115,7 @@ with
             birth_year.member_birth_year,
             ethnicity.member_ethnicity,
             gender.gender,
-            party.party
+            party.party,
             constituency.member_constituencies,
             latest_constituency.member_position as latest_member_constituency,
             appointments.member_appointments,

--- a/models/dim/dim_members.sql
+++ b/models/dim/dim_members.sql
@@ -29,6 +29,7 @@ with
                 struct(party, parliament)
             ) as party
         from {{ ref("stg_gsheet_member_party") }}
+        group by all
     ),
 
     full_name as (

--- a/models/mart/mart_attendance.sql
+++ b/models/mart/mart_attendance.sql
@@ -37,8 +37,8 @@ with
 
             -- member information
             attendance.member_name,
-            member_demographics.gender as member_gender,
-            member_demographics.member_ethnicity as member_ethnicity,
+            demo.gender as member_gender,
+            demo.member_ethnicity as member_ethnicity,
             member_constituency.constituency as member_constituency,
             party.party,
 

--- a/models/stg/google_sheet/schema.yml
+++ b/models/stg/google_sheet/schema.yml
@@ -127,7 +127,8 @@ sources:
           - name: member_name
             data_type: STRING
             tests:
-              - unique
+              - unique:
+                  column_names: [member_name, parliament]
           - name: party
             data_type: STRING
           - name: parliament

--- a/models/stg/google_sheet/schema.yml
+++ b/models/stg/google_sheet/schema.yml
@@ -114,6 +114,24 @@ sources:
               - unique
           - name: member_image_link
             data_type: STRING
+      - name: member_party
+        description: >
+          Which party each member belonged to in which parliament. If parliament is blank, then member was in the same party for all parliaments they were in.
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/']
+            sheet_range: members_party
+            skip_leading_rows: 1
+        columns:
+          - name: member_name
+            data_type: STRING
+            tests:
+              - unique
+          - name: party
+            data_type: STRING
+          - name: parliament
+            data_type: INTEGER
       - name: member_name_link
         description: >
           URL links to members in the parliament API
@@ -129,4 +147,20 @@ sources:
             tests:
               - unique
           - name: member_link_name
+            data_type: STRING
+      - name: member_gender
+        description: >
+          Gender of each MP.
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/']
+            sheet_range: members_gender
+            skip_leading_rows: 1
+        columns:
+          - name: member_name
+            data_type: STRING
+            tests:
+              - unique
+          - name: gender
             data_type: STRING

--- a/models/stg/google_sheet/schema.yml
+++ b/models/stg/google_sheet/schema.yml
@@ -126,7 +126,7 @@ sources:
         columns:
           - name: member_name
             data_type: STRING
-            tests:
+            data_tests:
               - unique:
                   column_names: [member_name, parliament]
           - name: party

--- a/models/stg/google_sheet/schema.yml
+++ b/models/stg/google_sheet/schema.yml
@@ -114,7 +114,7 @@ sources:
               - unique
           - name: member_image_link
             data_type: STRING
-      - name: member_party
+      - name: party
         description: >
           Which party each member belonged to in which parliament. If parliament is blank, then member was in the same party for all parliaments they were in.
         external:
@@ -148,7 +148,7 @@ sources:
               - unique
           - name: member_link_name
             data_type: STRING
-      - name: member_gender
+      - name: gender
         description: >
           Gender of each MP.
         external:

--- a/models/stg/google_sheet/schema.yml
+++ b/models/stg/google_sheet/schema.yml
@@ -114,3 +114,19 @@ sources:
               - unique
           - name: member_image_link
             data_type: STRING
+      - name: member_name_link
+        description: >
+          URL links to members in the parliament API
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/']
+            sheet_range: members_name_link
+            skip_leading_rows: 1
+        columns:
+          - name: member_name
+            data_type: STRING
+            tests:
+              - unique
+          - name: member_link_name
+            data_type: STRING

--- a/models/stg/google_sheet/stg_gsheet_member_gender.sql
+++ b/models/stg/google_sheet/stg_gsheet_member_gender.sql
@@ -1,0 +1,5 @@
+with
+    source as (select * from {{ source("google_sheets", "gender") }}),
+    renamed as (select member_name, gender as member_gender from source)
+select *
+from renamed

--- a/models/stg/google_sheet/stg_gsheet_member_name_link.sql
+++ b/models/stg/google_sheet/stg_gsheet_member_name_link.sql
@@ -1,0 +1,10 @@
+with
+    source as (select * from {{ source("google_sheets", "member_name_link") }}),
+    renamed as (
+        select
+            {{ adapter.quote("member_name") }} as member_name,
+            {{ adapter.quote("member_link_name") }} as member_name_website
+        from source
+    )
+select *
+from renamed

--- a/models/stg/google_sheet/stg_gsheet_member_party.sql
+++ b/models/stg/google_sheet/stg_gsheet_member_party.sql
@@ -1,0 +1,5 @@
+with
+    source as (select * from {{ source("google_sheets", "party") }}),
+    renamed as (select member_name, party as member_party, parliament from source)
+select *
+from renamed

--- a/models/stg/members_information/stg_members_full_name.sql
+++ b/models/stg/members_information/stg_members_full_name.sql
@@ -6,6 +6,29 @@ with
             {{ adapter.quote("converted") }} as member_name_website
 
         from source
+    ),
+    gsheet as (
+        select * from {{ ref("stg_gsheet_member_name_link") }}
+    ),
+
+    unioned as (
+        select *, 
+        -- set accessed at as last modified date
+        cast("2024-05-16" as date) as accessed_at
+        from renamed
+        union all
+        select *
+        from manual_gsheet
+    ),
+
+    -- filter latest non null entries --
+    filter_latest as (
+        select member_name, member_name_website
+        from unioned
+        where member_name_website is not null
+        qualify row_number() over(
+            partition by member_name order by accessed_at desc
+        ) = 1
     )
 select *
-from renamed
+from filter_latest

--- a/models/stg/members_information/stg_members_full_name.sql
+++ b/models/stg/members_information/stg_members_full_name.sql
@@ -18,7 +18,7 @@ with
         from renamed
         union all
         select *
-        from manual_gsheet
+        from gsheet
     ),
 
     -- filter latest non null entries --

--- a/models/stg/members_information/stg_members_image.sql
+++ b/models/stg/members_information/stg_members_image.sql
@@ -13,6 +13,14 @@ with
         union all
         select member_name, member_image_link
         from gsheet
+    ),
+     -- filter latest entries; nulls not dropped because there are nulls in manual gsheet --
+    filter_latest as (
+        select member_name, member_image_link
+        from unioned
+        qualify row_number() over(
+            partition by member_name order by accessed_at desc
+        ) = 1
     )
 select *
-from unioned
+from filter_latest

--- a/models/stg/members_information/stg_members_member_of_parliament.sql
+++ b/models/stg/members_information/stg_members_member_of_parliament.sql
@@ -55,7 +55,7 @@ with
             effective_to_date 
             order by accessed_at desc
         ) = 1
-    )
+    ),
 
     -- post-process
     add_latest_flag as (

--- a/models/stg/members_information/stg_members_member_of_parliament.sql
+++ b/models/stg/members_information/stg_members_member_of_parliament.sql
@@ -42,6 +42,21 @@ with
         from manual_gsheet
     ),
 
+     -- filter latest non null entries --
+    filter_latest as (
+        select member_name, member_constituency, effective_from_date, effective_to_date
+        from unioned
+        where member_constituency is not null
+        qualify row_number() over(
+            partition by 
+            member_name, 
+            member_constituency, 
+            effective_from_date, 
+            effective_to_date 
+            order by accessed_at desc
+        ) = 1
+    )
+
     -- post-process
     add_latest_flag as (
         select
@@ -58,7 +73,7 @@ with
                     effective_to_date
                     = max(effective_to_date) over (partition by member_name)
             end as is_latest_constituency
-        from unioned
+        from filter_latest
     )
 select *
 from add_latest_flag

--- a/models/stg/members_information/stg_members_select_committee.sql
+++ b/models/stg/members_information/stg_members_select_committee.sql
@@ -26,6 +26,7 @@ with
                     session,
                     member_committee,
                     member_committee_position
+                order by accessed_at desc
             )
             = 1
     ),

--- a/models/stg/members_information/stg_members_year_of_birth.sql
+++ b/models/stg/members_information/stg_members_year_of_birth.sql
@@ -18,6 +18,16 @@ with
         union all
         select member_name, member_birth_year
         from manual_gsheet
+    ),
+
+    -- filter latest non null entries --
+    filter_latest as (
+        select member_name, year_of_birth
+        from unioned
+        where year_of_birth is not null
+        qualify row_number() over(
+            partition by member_name order by accessed_at desc
+        ) = 1
     )
 select *
-from unioned
+from filter_latest

--- a/seeds/member.csv
+++ b/seeds/member.csv
@@ -197,7 +197,7 @@ Abdul Muhaimin,WP,M
 Alex Yeo,PAP,M
 Andre Low,WP,M
 Cai Yinzhou,PAP,M
-Cassandra Lee ,PAP,F
+Cassandra Lee,PAP,F
 Charlene Chen,PAP,F
 Choo Pei Ling,PAP,F
 David Hoe,PAP,M

--- a/seeds/member.csv
+++ b/seeds/member.csv
@@ -193,3 +193,36 @@ Zainal Sapari,PAP,M
 Zainudin Nordin,PAP,M
 Zaqy Mohamad,PAP,M
 Zhulkarnain Abdul Rahim,PAP,M
+Abdul Muhaimin,WP,M
+Alex Yeo,PAP,M
+Andre Low,WP,M
+Cai Yinzhou,PAP,M
+Cassandra Lee ,PAP,F
+Charlene Chen,PAP,F
+Choo Pei Ling,PAP,F
+David Hoe,PAP,M
+David Neo,PAP,M
+Diana Pang,PAP,F
+Dinesh Vasu Dash,PAP,M
+Eileen Chong,WP,F
+Elysa Chen,PAP,F
+Foo Cexiang,PAP,M
+Gabriel Lam,PAP,M
+Goh Sze Kee,PAP,F
+Goh Hanyan,PAP,F
+Goh Pei Ming,PAP,M
+Hamid Razak,PAP,M
+Hazlina Abdul Halim,PAP,F
+Jackson Lam,PAP,M
+Jasmin Lau,PAP,F
+Jeffrey Siow,PAP,M
+Kenneth Tiong,WP,M
+Lee Hong Chuang,PAP,M
+Lee Hui Ying,PAP,F
+Fadli Fawzi,WP,M
+Ng Chee Meng,PAP,M
+Ng Shi Xuan,PAP,M
+Shawn Loh,PAP,M
+Syed Harun Alhabsyi,PAP,M
+Valerie Lee,PAP,F
+Victor Lye,PAP,M


### PR DESCRIPTION
This PR changes join and source logics of certain models, particularly those related to member demographics (gender, ethnicity) and party affiliation (which party and which parliament) to pull from updated sources.

In bigquery, tables have been updated with latest member information. dim_members is also now updated to reflect member party and parliament as arrays - the reason being some members (Syed Harun) have switched parties and the previous join statements assume one party per MP. Affected models have been amended to pull the correct party and parliament info per member.

member information (gender and party) is also now pulled solely from google sheets instead of seed>member.csv. Reason being, it feels tidier to have all manual tables in google sheets where we may need to make changes more often. 