### PR TITLE
fix dbt errors

### DIFF
--- a/models/mart/mart_speeches.sql
+++ b/models/mart/mart_speeches.sql
@@ -74,7 +74,7 @@ with
             speeches.member_name,
             demo.gender as member_gender,
             demo.member_ethnicity as member_ethnicity,
-            party.party,
+            party.party as member_party,
             case
                 when party.party = 'NMP'
                 then 'Nominated Member of Parliament'

--- a/models/stg/google_sheet/schema.yml
+++ b/models/stg/google_sheet/schema.yml
@@ -126,13 +126,16 @@ sources:
         columns:
           - name: member_name
             data_type: STRING
-            data_tests:
-              - unique:
-                  column_names: [member_name, parliament]
           - name: party
             data_type: STRING
           - name: parliament
             data_type: INTEGER
+        tests:
+          - dbt_utils.unique_combination_of_columns:
+              combination_of_columns:
+                - member_name
+                - party
+                - parliament
       - name: member_name_link
         description: >
           URL links to members in the parliament API

--- a/models/stg/google_sheet/stg_gsheet_member_gender.sql
+++ b/models/stg/google_sheet/stg_gsheet_member_gender.sql
@@ -1,5 +1,4 @@
 with
-    source as (select * from {{ source("google_sheets", "gender") }}),
-    renamed as (select member_name, gender as member_gender from source)
+    source as (select * from {{ source("google_sheets", "gender") }})
 select *
-from renamed
+from source

--- a/models/stg/google_sheet/stg_gsheet_member_image_link.sql
+++ b/models/stg/google_sheet/stg_gsheet_member_image_link.sql
@@ -2,7 +2,9 @@ with
     source as (select * from {{ source("google_sheets", "member_image_link") }}),
     renamed as (
         select
-            {{ adapter.quote("member_name") }}, {{ adapter.quote("member_image_link") }}
+            {{ adapter.quote("member_name") }}, 
+            {{ adapter.quote("member_image_link") }},
+            cast(accessed_at as date) as accessed_at
 
         from source
     )

--- a/models/stg/google_sheet/stg_gsheet_member_name_link.sql
+++ b/models/stg/google_sheet/stg_gsheet_member_name_link.sql
@@ -3,7 +3,8 @@ with
     renamed as (
         select
             {{ adapter.quote("member_name") }} as member_name,
-            {{ adapter.quote("member_link_name") }} as member_name_website
+            {{ adapter.quote("member_link_name") }} as member_name_website,
+            cast(accessed_at as date) as accessed_at
         from source
     )
 select *

--- a/models/stg/google_sheet/stg_gsheet_member_party.sql
+++ b/models/stg/google_sheet/stg_gsheet_member_party.sql
@@ -1,5 +1,4 @@
 with
-    source as (select * from {{ source("google_sheets", "party") }}),
-    renamed as (select member_name, party as member_party, parliament from source)
+    source as (select * from {{ source("google_sheets", "party") }})
 select *
-from renamed
+from source

--- a/models/stg/members_information/stg_members_image.sql
+++ b/models/stg/members_information/stg_members_image.sql
@@ -4,14 +4,15 @@ with
     renamed as (
         select
             {{ adapter.quote("member_name") }} as member_name,
-            {{ adapter.quote("image_link") }} as member_image_link
+            {{ adapter.quote("image_link") }} as member_image_link,
+            cast(accessed_at as date) as accessed_at
         from source
     ),
     unioned as (
-        select member_name, member_image_link
+        select member_name, member_image_link, accessed_at
         from renamed
         union all
-        select member_name, member_image_link
+        select member_name, member_image_link, accessed_at
         from gsheet
     ),
      -- filter latest entries; nulls not dropped because there are nulls in manual gsheet --

--- a/models/stg/members_information/stg_members_member_of_parliament.sql
+++ b/models/stg/members_information/stg_members_member_of_parliament.sql
@@ -1,13 +1,50 @@
 with
     source as (select * from {{ source("raw", "members_member_of_parliament") }}),
 
+    current_members as (
+        select distinct member_name
+        from source
+        where accessed_at >= (select max(accessed_at) from source)
+    ),
+    clean_raw as (
+        select
+            member_name,
+            constituency,
+            from_date,
+            case
+                when
+                    to_date is null
+                    and member_name not in (select member_name from current_members)
+                then '2025-04-14'
+                else to_date
+            end as to_date,
+            case
+                when
+                    to_date is null
+                    and member_name not in (select member_name from current_members)
+                then replace(date_range, 'Current', '14 April 2025')
+                else date_range
+            end as date_range,
+            accessed_at
+        from source
+        -- extract non current members, and for current members, take only most
+        -- recently scraped info
+        where
+            member_name not in (select member_name from current_members)
+            or (
+                member_name in (select member_name from current_members)
+                and accessed_at = (select max(accessed_at) from source)
+            )
+    ),
+
     renamed as (
         select
             {{ adapter.quote("member_name") }} as member_name,
             {{ adapter.quote("constituency") }} as member_constituency,
             cast({{ adapter.quote("from_date") }} as date) as effective_from_date,
             cast({{ adapter.quote("to_date") }} as date) as effective_to_date,
-            {{ adapter.quote("date_range") }} as date_range  -- for conditional only
+            {{ adapter.quote("date_range") }} as date_range,  -- for conditional only
+            cast(accessed_at as date) as accessed_at
 
         from source
     ),
@@ -20,7 +57,8 @@ with
             effective_from_date,
             case
                 when lower(date_range) like '%current%' then null else effective_to_date
-            end as effective_to_date
+            end as effective_to_date,
+            accessed_at
         from renamed
     ),
 
@@ -30,15 +68,16 @@ with
             member_name,
             trim(replace(member_constituency, chr(160), ' ')) as member_constituency,
             effective_from_date,
-            effective_to_date
+            effective_to_date,
+            accessed_at
         from {{ ref("stg_gsheet_member_of_parliament") }}
     ),
 
     unioned as (
-        select member_name, member_constituency, effective_from_date, effective_to_date
+        select member_name, member_constituency, effective_from_date, effective_to_date, accessed_at
         from process
         union all
-        select member_name, member_constituency, effective_from_date, effective_to_date
+        select member_name, member_constituency, effective_from_date, effective_to_date, accessed_at
         from manual_gsheet
     ),
 

--- a/models/stg/members_information/stg_members_office_holding.sql
+++ b/models/stg/members_information/stg_members_office_holding.sql
@@ -1,25 +1,63 @@
 with
     source as (select * from {{ source("raw", "members_office_holding") }}),
+
+    current_members as (
+        select distinct member_name
+        from source
+        where accessed_at >= (select max(accessed_at) from source)
+    ),
+    clean_raw as (
+        select
+            member_name,
+            position,
+            from_date,
+            case
+                when
+                    to_date is null
+                    and member_name not in (select member_name from current_members)
+                then '2025-04-14'
+                else to_date
+            end as to_date,
+            case
+                when
+                    to_date is null
+                    and member_name not in (select member_name from current_members)
+                then replace(date_range, 'Current', '14 April 2025')
+                else date_range
+            end as date_range,
+            accessed_at
+        from source
+        -- extract non current members, and for current members, take only most
+        -- recently scraped info
+        where
+            member_name not in (select member_name from current_members)
+            or (
+                member_name in (select member_name from current_members)
+                and accessed_at = (select max(accessed_at) from source)
+            )
+    ),
+
     renamed as (
         select
-            {{ adapter.quote("member_name") }} as member_name,
+            member_name,
             {{ adapter.quote("position") }} as member_appointment,
             cast({{ adapter.quote("from_date") }} as date) as effective_from_date,
-            cast({{ adapter.quote("to_date") }} as date) as effective_to_date
-        from source
+            cast({{ adapter.quote("to_date") }} as date) as effective_to_date,
+            cast(accessed_at as date) as accessed_at
+        from clean_raw
     ),
 
     -- union manually-filled information
     manual_gsheet as (
-        select member_name, member_appointment, effective_from_date, effective_to_date
+        select *
         from {{ ref("stg_gsheet_office_holding") }}
     ),
 
     unioned as (
-        select member_name, member_appointment, effective_from_date, effective_to_date
+        select member_name, member_appointment, effective_from_date, effective_to_date, accessed_at
         from renamed
         union all
-        select member_name, member_appointment, effective_from_date, effective_to_date
+        select member_name, member_appointment, effective_from_date, effective_to_date, accessed_at
         from manual_gsheet
     ),
 

--- a/models/stg/members_information/stg_members_select_committee.sql
+++ b/models/stg/members_information/stg_members_select_committee.sql
@@ -6,7 +6,8 @@ with
             {{ adapter.quote("parliament") }} as parliament,
             {{ adapter.quote("session") }} as session,
             {{ adapter.quote("committee") }} as member_committee,
-            {{ adapter.quote("position") }} as member_committee_position
+            {{ adapter.quote("position") }} as member_committee_position,
+            cast(accessed_at as date) as accessed_at
 
         from source
     ),

--- a/models/stg/members_information/stg_members_year_of_birth.sql
+++ b/models/stg/members_information/stg_members_year_of_birth.sql
@@ -4,27 +4,30 @@ with
         select
             {{ adapter.quote("member_name") }} as member_name,
             cast({{ adapter.quote("year_of_birth") }} as int) as member_birth_year,
-
+            cast(accessed_at as date) as accessed_at
         from source
     ),
     -- union manually-filled information
     manual_gsheet as (
-        select member_name, member_birth_year from {{ ref("stg_gsheet_year_of_birth") }}
+        select member_name, 
+        member_birth_year,
+        cast(accessed_at as date) as accessed_at 
+        from {{ ref("stg_gsheet_year_of_birth") }}
     ),
 
     unioned as (
-        select member_name, member_birth_year
+        select member_name, member_birth_year, accessed_at
         from renamed
         union all
-        select member_name, member_birth_year
+        select member_name, member_birth_year, accessed_at
         from manual_gsheet
     ),
 
     -- filter latest non null entries --
     filter_latest as (
-        select member_name, year_of_birth
+        select member_name, member_birth_year
         from unioned
-        where year_of_birth is not null
+        where member_birth_year is not null
         qualify row_number() over(
             partition by member_name order by accessed_at desc
         ) = 1


### PR DESCRIPTION
fix errors that were popping up in dbt test and build. Most errors to do with how raw.members_member_office_holding and raw.members_member_of_parliament were handled, in that there were duplicates from different scraping runs that were not filtered. 