### PR TITLE
Fix mart speeches duplicates

### DIFF
--- a/models/dashboard/dash_demographics.sql
+++ b/models/dashboard/dash_demographics.sql
@@ -3,7 +3,7 @@ with
         select
             members.member_name,
             constituency.parliament,
-            party.party,
+            party.party as member_party,
             constituency.member_constituency,
             members.member_ethnicity,
             members.gender,

--- a/models/stg/google_sheet/schema.yml
+++ b/models/stg/google_sheet/schema.yml
@@ -42,6 +42,8 @@ sources:
         columns:
           - name: member_name
             data_type: STRING
+            tests:
+              - unique
           - name: ethnicity
             data_type: STRING
           - name: is_ethnicity_certain
@@ -168,3 +170,23 @@ sources:
               - unique
           - name: gender
             data_type: STRING
+      - name: parliament_dates
+        description: >
+          Date ranges of each parliament
+        external:
+          options:
+            format: GOOGLE_SHEETS
+            uris: ['https://docs.google.com/spreadsheets/d/1Wk_PDlQbWWViTV9NmDPsXwu54TD96ltEycLAKOHe1fA/']
+            sheet_range: parliament_dates
+            skip_leading_rows: 1
+        columns:
+          - name: parliament
+            data_type: INTEGER
+            tests:
+              - unique
+          - name: from_date
+            data_type: DATE
+          - name: to_date
+            data_type: DATE
+          - name: current
+            data_type: BOOLEAN

--- a/models/stg/google_sheet/stg_gsheet_parliament_dates.sql
+++ b/models/stg/google_sheet/stg_gsheet_parliament_dates.sql
@@ -1,0 +1,4 @@
+with
+    source as (select * from {{ source("google_sheets", "parliament_dates") }})
+select *
+from source

--- a/models/stg/google_sheet/stg_gsheet_parliament_dates.sql
+++ b/models/stg/google_sheet/stg_gsheet_parliament_dates.sql
@@ -1,3 +1,6 @@
+-- materialize as table to allow for use without needing to expand drive scopes for other projects --
+{{ config(materialized='table') }}
+
 with
     source as (select * from {{ source("google_sheets", "parliament_dates") }})
 select *

--- a/models/stg/members_information/schema.yml
+++ b/models/stg/members_information/schema.yml
@@ -25,6 +25,7 @@ models:
             - member_name
             - member_constituency
             - effective_from_date
+            - effective_to_date
   - name: stg_members_office_holding
     description: '{{ doc("models_members_office_holding") }}'
     tests:
@@ -33,6 +34,7 @@ models:
             - member_name
             - member_appointment
             - effective_from_date
+            - effective_to_date
   - name: stg_members_select_committee
     description: '{{ doc("models_members_select_committee") }}'
     tests:

--- a/models/stg/members_information/stg_members_member_of_parliament.sql
+++ b/models/stg/members_information/stg_members_member_of_parliament.sql
@@ -1,41 +1,7 @@
 with
     source as (select * from {{ source("raw", "members_member_of_parliament") }}),
 
-    current_members as (
-        select distinct member_name
-        from source
-        where accessed_at >= (select max(accessed_at) from source)
-    ),
-    clean_raw as (
-        select
-            member_name,
-            constituency,
-            from_date,
-            case
-                when
-                    to_date is null
-                    and member_name not in (select member_name from current_members)
-                then '2025-04-14'
-                else to_date
-            end as to_date,
-            case
-                when
-                    to_date is null
-                    and member_name not in (select member_name from current_members)
-                then replace(date_range, 'Current', '14 April 2025')
-                else date_range
-            end as date_range,
-            accessed_at
-        from source
-        -- extract non current members, and for current members, take only most
-        -- recently scraped info
-        where
-            member_name not in (select member_name from current_members)
-            or (
-                member_name in (select member_name from current_members)
-                and accessed_at = (select max(accessed_at) from source)
-            )
-    ),
+    parliament_dates as (select * from {{ ref("stg_gsheet_parliament_dates") }}),
 
     renamed as (
         select
@@ -47,6 +13,45 @@ with
             cast(accessed_at as date) as accessed_at
 
         from source
+    ),
+
+    current_members as (
+        select distinct member_name
+        from renamed
+        where accessed_at = (select max(accessed_at) from renamed)
+    ),
+    clean_raw as (
+        select
+            renamed.member_name,
+            renamed.member_constituency,
+            renamed.effective_from_date,
+            case
+                when
+                    renamed.effective_to_date is null
+                    and renamed.member_name not in (select member_name from current_members)
+                then pd.to_date
+                else renamed.effective_to_date
+            end as effective_to_date,
+            case
+                when
+                    renamed.effective_to_date is null
+                    and renamed.member_name not in (select member_name from current_members)
+                then replace(date_range, 'Current', FORMAT_DATE('%-d %B %Y', pd.to_date)
+)
+                else date_range
+            end as date_range,
+        renamed.accessed_at
+        from renamed
+        left join parliament_dates pd
+        on renamed.effective_from_date between pd.from_date and pd.to_date
+        -- extract non current members, and for current members, take only most
+        -- recently scraped info
+        where
+            renamed.member_name not in (select member_name from current_members)
+            or (
+                renamed.member_name in (select member_name from current_members)
+                and renamed.accessed_at = (select max(accessed_at) from renamed)
+            )
     ),
 
     process as (
@@ -90,8 +95,7 @@ with
             partition by 
             member_name, 
             member_constituency, 
-            effective_from_date, 
-            effective_to_date 
+            effective_from_date
             order by accessed_at desc
         ) = 1
     ),

--- a/models/stg/members_information/stg_members_office_holding.sql
+++ b/models/stg/members_information/stg_members_office_holding.sql
@@ -1,41 +1,7 @@
 with
     source as (select * from {{ source("raw", "members_office_holding") }}),
 
-    current_members as (
-        select distinct member_name
-        from source
-        where accessed_at >= (select max(accessed_at) from source)
-    ),
-    clean_raw as (
-        select
-            member_name,
-            position,
-            from_date,
-            case
-                when
-                    to_date is null
-                    and member_name not in (select member_name from current_members)
-                then '2025-04-14'
-                else to_date
-            end as to_date,
-            case
-                when
-                    to_date is null
-                    and member_name not in (select member_name from current_members)
-                then replace(date_range, 'Current', '14 April 2025')
-                else date_range
-            end as date_range,
-            accessed_at
-        from source
-        -- extract non current members, and for current members, take only most
-        -- recently scraped info
-        where
-            member_name not in (select member_name from current_members)
-            or (
-                member_name in (select member_name from current_members)
-                and accessed_at = (select max(accessed_at) from source)
-            )
-    ),
+    parliament_dates as (select * from {{ ref("stg_gsheet_parliament_dates") }}),
 
     renamed as (
         select
@@ -44,7 +10,38 @@ with
             cast({{ adapter.quote("from_date") }} as date) as effective_from_date,
             cast({{ adapter.quote("to_date") }} as date) as effective_to_date,
             cast(accessed_at as date) as accessed_at
-        from clean_raw
+        from source
+    ),
+
+    current_members as (
+        select distinct member_name
+        from renamed
+        where accessed_at = (select max(accessed_at) from renamed)
+    ),
+    clean_raw as (
+        select
+            renamed.member_name,
+            renamed.member_appointment,
+            renamed.effective_from_date,
+            case
+                when
+                    renamed.effective_to_date is null
+                    and renamed.member_name not in (select member_name from current_members)
+                then pd.to_date
+                else renamed.effective_to_date
+            end as effective_to_date,
+            renamed.accessed_at
+        from renamed
+        left join parliament_dates pd
+        on renamed.effective_from_date between pd.from_date and pd.to_date
+        -- extract non current members, and for current members, take only most
+        -- recently scraped info
+        where
+            renamed.member_name not in (select member_name from current_members)
+            or (
+                renamed.member_name in (select member_name from current_members)
+                and renamed.accessed_at = (select max(accessed_at) from renamed)
+            )
     ),
 
     -- union manually-filled information
@@ -55,7 +52,7 @@ with
 
     unioned as (
         select member_name, member_appointment, effective_from_date, effective_to_date, accessed_at
-        from renamed
+        from clean_raw
         union all
         select member_name, member_appointment, effective_from_date, effective_to_date, accessed_at
         from manual_gsheet
@@ -69,8 +66,7 @@ with
         qualify row_number() over(
             partition by member_name, 
             member_appointment, 
-            effective_from_date, 
-            effective_to_date 
+            effective_from_date
             order by accessed_at desc
         ) = 1
     ),


### PR DESCRIPTION
This PR:
1. fixes stg models (members_of_parliament, members_office_holding) to prevent duplicates on join
2. results in duplicate free mart_speeches table that enable gpt summaries to be generated
3. adds duplication tests